### PR TITLE
Fix cbsd expose not working without ipfw enabled

### DIFF
--- a/tools/expose
+++ b/tools/expose
@@ -198,7 +198,9 @@ fi
 
 [ -z "${proto}" ] && proto="tcp"
 [ -z "${inaddr}" ] && inaddr="nodeip"  # "nodeip"  - reserverd word for $nodeip variable
-[ "$( /sbin/sysctl -qn net.inet.ip.fw.enable 2>/dev/null )" != "1" ] && err 1 "${MAGENTA}IPFW is not enabled${NORMAL}"
+if [ "${nat_enable}" = "ipfw" ]; then
+	[ "$( /sbin/sysctl -qn net.inet.ip.fw.enable 2>/dev/null )" != "1" ] && err 1 "${MAGENTA}IPFW is not enabled${NORMAL}"
+fi
 # init ipfw number
 get_first_fwnum
 [ -z "${fwnum}" ] && err 1 "${MAGENTA}Empty fwnum variable${NORMAL}"


### PR DESCRIPTION
I wrapped the line that checks if net.inet.ip.fw.enable is set in an if that just checks if cbsd is set up to use ipfw. Because if its not then that check won't pass at all since net.inet.ip.fw doesn't exist. 

This allows pf users to use expose without having to enable ipfw