### PR TITLE
bump to 11.1.2

### DIFF
--- a/ObsoleteFiles
+++ b/ObsoleteFiles
@@ -46,4 +46,5 @@ etc/defaults/vm-dflybsd-x86-LATEST.conf
 etc/defaults/vm-freebsd-FreeNAS-x64-10.conf
 etc/defaults/vm-linux-Kali-2016-amd64.conf
 etc/defaults/vm-linux-ubuntuserver-x86-16.10.conf
+etc/defaults/vm-linux-CentOS-7-x86_64.conf
 "

--- a/bin/cbsdsh/about.h
+++ b/bin/cbsdsh/about.h
@@ -1,1 +1,1 @@
-#define VERSION "11.1.1"
+#define VERSION "11.1.2"

--- a/cbsd.conf
+++ b/cbsd.conf
@@ -3,7 +3,7 @@ unset oarch over ostable arch target_arch ver stable
 
 # defines
 product="CBSD"
-myversion="11.1.1"
+myversion="11.1.2"
 
 if [ -z "${workdir}" ]; then
 	echo "no workdir"

--- a/cbsd.lua
+++ b/cbsd.lua
@@ -1,5 +1,5 @@
 product="CBSD"
-myversion="11.1.1"
+myversion="11.1.2"
 
 if not workdir then
 	print ( "no workdir" )

--- a/emulator.subr
+++ b/emulator.subr
@@ -10,7 +10,7 @@ init_usermode_emul()
 		[ "${emulator}" = "bhyve" ] && return 0
 		emultest=$( which ${emulator} )
 		[ $? -eq 1 -o -z "${emultest}" ] && err 1 "No such emulator: ${emulator}"
-		static_test=$( ldd ${emultest} 2>&1|grep "not a dynamic ELF" )
+		static_test=$( /usr/bin/ldd ${emultest} 2>&1|/usr/bin/grep "not a dynamic ELF" )
 		[ -z "${static_test}" ] && err 1 "${emultest} must be static. Please rebuild them"
 	else
 		err 1 "No such emulator variable"

--- a/etc/defaults/bhyve-default-default.conf
+++ b/etc/defaults/bhyve-default-default.conf
@@ -70,8 +70,13 @@ data="${jaildatadir}/${jname}-${jaildatapref}"
 
 # BHYVE AREA
 boot_from_grub=0
-vm_cpus="1"
-vm_ram="1g"
+
+#vm_cpus="1"
+#vm_ram="1g"
+#imgsize="10g"
+# or via packages:
+vm_package="small1"
+
 vm_os_type="freebsd"
 vm_hostbridge="hostbridge"
 vm_boot="hdd"

--- a/etc/defaults/blogin.conf
+++ b/etc/defaults/blogin.conf
@@ -3,11 +3,12 @@
 # by placing this file into ${jailsysdir}/jname/etc
 
 # custom command for login
-# - internal - internal/default behavior
+# - login_cmd="internal" - internal/default behavior
 # Another example:
-#   "/usr/bin/ssh your_user@${ip4_addr}"
-#   "login -f root ${jname}"
-#   "/usr/local/bin/vncviewer ${ip4_addr}"
-#   "/usr/local/bin/xfreerdp /w:1280 /h:1024  /u:Administrator /v:${ip4_addr}"
+#   login_cmd="/usr/bin/ssh your_user@${ip4_addr}"
+#   login_cmd="su -m user -c \"vncviewer 127.0.0.1:${vm_vnc_port}\""
+#   login_cmd="login -f root ${jname}"
+#   login_cmd="/usr/local/bin/vncviewer ${ip4_addr}"
+#   login_cmd="/usr/local/bin/xfreerdp /w:1280 /h:1024  /u:Administrator /v:${ip4_addr}"
 
-login_cmd="native"
+login_cmd="internal"

--- a/etc/defaults/jlogin.conf
+++ b/etc/defaults/jlogin.conf
@@ -9,11 +9,12 @@ tmux_login="1"
 always_rlogin="0"
 
 # custom command for login
-# - internal - internal/default behavior
+# - login_cmd="internal" - internal/default behavior
 # Another example:
-#   "/usr/bin/ssh your_user@${ip4_addr}"
-#   "login -f root ${jname}"
-#   "/usr/local/bin/vncviewer ${ip4_addr}"
-#   "/usr/local/bin/xfreerdp /w:1280 /h:1024  /u:Administrator /v:${ip4_addr}"
+#   login_cmd="/usr/bin/ssh your_user@${ip4_addr}"
+#   login_cmd="su -m user -c \"vncviewer 127.0.0.1:${vm_vnc_port}\""
+#   login_cmd="login -f root ${jname}"
+#   login_cmd="/usr/local/bin/vncviewer ${ip4_addr}"
+#   login_cmd="/usr/local/bin/xfreerdp /w:1280 /h:1024  /u:Administrator /v:${ip4_addr}"
 
-login_cmd="native"
+login_cmd="internal"

--- a/etc/defaults/vm-dflybsd-x86-4.conf
+++ b/etc/defaults/vm-dflybsd-x86-4.conf
@@ -36,12 +36,11 @@ virtio_type="ahci-hd"
 
 default_jailname="dfly"
 
+vm_package="small1"
+vm_ram="4g"
 imgsize="40g"
 boot_from_grub=0
 
-vm_ram="4g"
-
-vm_ram="4g"
 vm_efi="uefi"
 vm_vnc_port="0"
 

--- a/etc/defaults/vm-freebsd-BSDRP-x64-1.70.conf
+++ b/etc/defaults/vm-freebsd-BSDRP-x64-1.70.conf
@@ -19,17 +19,13 @@ register_iso_as="iso-BSDRP-x64-1.70"
 iso_extract="/usr/bin/xz -d "
 
 default_jailname="bsdrp"
-imgsize="4g"
-
-vm_ram="1g"
+vm_package="small1"
 
 active=0
 
 # VNC
 vm_vnc_port="0"
 vm_efi="uefi"
-
-vm_ram="1g"
 
 # VirtualBox Area
 virtualbox_ostype="FreeBSD_64"

--- a/etc/defaults/vm-freebsd-ClonOS-x64-12.0.conf
+++ b/etc/defaults/vm-freebsd-ClonOS-x64-12.0.conf
@@ -14,15 +14,14 @@ register_iso_name="cbsd-iso-${iso_img}"
 register_iso_as="iso-clonoins"
 
 default_jailname="clonos"
+vm_package="small1"
 imgsize="20g"
+vm_cpus="2"
 
 # disable profile?
 active=0
 # Available in ClonOS?
 clonos_active=0
-
-vm_cpus="2"
-vm_ram="1g"
 
 # VNC
 vm_vnc_port="0"

--- a/etc/defaults/vm-freebsd-FreeBSD-x64-10.3.conf
+++ b/etc/defaults/vm-freebsd-FreeBSD-x64-10.3.conf
@@ -22,7 +22,7 @@ register_iso_name="cbsd-iso-${iso_img}"
 register_iso_as="iso-FreeBSD-x64-10.3"
 
 default_jailname="freebsd"
-imgsize="4g"
+vm_package="small1"
 
 # disable profile?
 active=1
@@ -32,8 +32,6 @@ clonos_active=1
 ## VNC. Not compatible with FreeBSD 10.3
 vm_vnc_port="0"
 vm_efi="uefi"
-
-vm_ram="1g"
 
 # VirtualBox Area
 virtualbox_ostype="FreeBSD_64"

--- a/etc/defaults/vm-freebsd-FreeBSD-x64-11.0.conf
+++ b/etc/defaults/vm-freebsd-FreeBSD-x64-11.0.conf
@@ -22,7 +22,6 @@ register_iso_name="cbsd-iso-${iso_img}"
 register_iso_as="iso-FreeBSD-11.0-RELEASE-amd64-disc1"	# this is vm_iso_path in vm config
 
 default_jailname="freebsd"
-imgsize="4g"
 
 # disable profile?
 active=1
@@ -34,7 +33,7 @@ clonos_active=1
 vm_vnc_port="0"
 vm_efi="uefi"
 
-vm_ram="1g"
+vm_package="small1"
 
 # VirtualBox Area
 virtualbox_ostype="FreeBSD_64"

--- a/etc/defaults/vm-freebsd-FreeBSD-x64-11.1.conf
+++ b/etc/defaults/vm-freebsd-FreeBSD-x64-11.1.conf
@@ -20,7 +20,6 @@ register_iso_name="cbsd-iso-${iso_img}"
 register_iso_as="iso-FreeBSD-11.1-RELEASE-amd64-disc1"	# this is vm_iso_path in vm config
 
 default_jailname="freebsd"
-imgsize="4g"
 
 # disable profile?
 active=1
@@ -31,7 +30,7 @@ clonos_active=1
 vm_vnc_port="0"
 vm_efi="uefi"
 
-vm_ram="1g"
+vm_package="small1"
 
 # VirtualBox Area
 virtualbox_ostype="FreeBSD_64"

--- a/etc/defaults/vm-freebsd-FreeBSD-x64-12.0-LATEST.conf
+++ b/etc/defaults/vm-freebsd-FreeBSD-x64-12.0-LATEST.conf
@@ -15,7 +15,6 @@ register_iso_name="cbsd-iso-${iso_img}"
 register_iso_as="iso-FreeBSD-x64-12.0"
 
 default_jailname="freebsd"
-imgsize="4g"
 
 # disable profile?
 active=0
@@ -27,7 +26,7 @@ clonos_active=0
 vm_vnc_port="0"
 vm_efi="uefi"
 
-vm_ram="1g"
+vm_package="small1"
 
 # VirtualBox Area
 virtualbox_ostype="FreeBSD_64"

--- a/etc/defaults/vm-freebsd-FreeNAS-x64-11.conf
+++ b/etc/defaults/vm-freebsd-FreeNAS-x64-11.conf
@@ -15,7 +15,6 @@ register_iso_name="cbsd-iso-${iso_img}"
 register_iso_as="iso-FreeNAS-x64-11"
 
 default_jailname="freenas"
-imgsize="8g"
 
 # disable profile?
 active=1
@@ -26,8 +25,6 @@ clonos_active=0
 # VNC
 vm_vnc_port="0"
 vm_efi="uefi"
-
-vm_ram="4g"
 
 # VirtualBox Area
 virtualbox_ostype="FreeBSD_64"

--- a/etc/defaults/vm-freebsd-NAS4Free-x64-11.conf
+++ b/etc/defaults/vm-freebsd-NAS4Free-x64-11.conf
@@ -15,15 +15,12 @@ register_iso_name="cbsd-iso-${iso_img}"
 register_iso_as="iso-NAS4Free-x64-11"
 
 default_jailname="nas4free"
-imgsize="6g"
-vm_ram="2g"
+vm_package="small1"
 
 #virtio_type="ahci-hd"
 
 # disable profile?
 active=0
-
-vm_ram="1g"
 
 # VNC
 vm_vnc_port="0"

--- a/etc/defaults/vm-freebsd-OPNsense-17-RELEASE-amd64.conf
+++ b/etc/defaults/vm-freebsd-OPNsense-17-RELEASE-amd64.conf
@@ -24,11 +24,9 @@ iso_img_dist="OPNsense-17.7-OpenSSL-dvd-amd64.iso.bz2"
 register_iso_name="cbsd-iso-${iso_img}"
 register_iso_as="iso-OPNsense-17"
 
-
 iso_extract="/usr/bin/bzip2 -d "
 
 default_jailname="opnsense"
-imgsize="4g"
 
 #virtio_type="ahci-hd"
 
@@ -38,7 +36,7 @@ active=1
 # Available in ClonOS?
 clonos_active=1
 
-vm_ram="2g"
+vm_package="small1"
 
 vm_vnc_port="0"
 vm_efi="uefi"

--- a/etc/defaults/vm-freebsd-TrueOS-x64-latest.conf
+++ b/etc/defaults/vm-freebsd-TrueOS-x64-latest.conf
@@ -15,8 +15,7 @@ register_iso_as="iso-${vm_profile}"
 
 default_jailname="trueos"
 
-# require for 10+ g
-imgsize="10g"
+vm_package="small1"
 
 # disable: no mouse in VNC - need to investigation
 # disable profile?
@@ -25,8 +24,6 @@ active=0
 # VNC
 vm_vnc_port="0"
 vm_efi="uefi"
-
-vm_ram="1g"
 
 # VirtualBox Area
 virtualbox_ostype="FreeBSD_64"

--- a/etc/defaults/vm-freebsd-kFreeBSD-amd64-7.conf
+++ b/etc/defaults/vm-freebsd-kFreeBSD-amd64-7.conf
@@ -11,8 +11,6 @@ iso_site="http://cdimage.debian.org/debian-cd/7.11.0/kfreebsd-amd64/iso-cd/ http
 iso_img="debian-7.11.0-kfreebsd-amd64-CD-1.iso"
 
 default_jailname="kfreebsd"
-imgsize="4g"
-
 # register_iso as:
 register_iso_name="cbsd-iso-${iso_img}"
 register_iso_as="iso-${vm_profile}"
@@ -21,7 +19,7 @@ boot_from_grub=0
 
 vm_vnc_port="0"
 vm_efi="uefi"
-vm_ram="1g"
+vm_package="small1"
 
 # disable profile?
 active=0

--- a/etc/defaults/vm-freebsd-kFreeBSD-amd64-8.conf
+++ b/etc/defaults/vm-freebsd-kFreeBSD-amd64-8.conf
@@ -11,7 +11,7 @@ iso_site="http://cdimage.debian.org/debian-cd/8.7.1/kfreebsd-amd64/iso-cd/ http:
 iso_img="debian-8.7.1-kfreebsd-amd64-CD-1.iso"
 
 default_jailname="kfreebsd"
-imgsize="4g"
+vm_package="small1"
 
 # register_iso as:
 register_iso_name="cbsd-iso-${iso_img}"
@@ -21,7 +21,6 @@ boot_from_grub=0
 
 vm_vnc_port="0"
 vm_efi="uefi"
-vm_ram="1g"
 
 # disable profile?
 active=0

--- a/etc/defaults/vm-linux-CentOS-6-x86_64.conf
+++ b/etc/defaults/vm-linux-CentOS-6-x86_64.conf
@@ -35,7 +35,7 @@ imgsize="6g"
 #boot_from_grub=1
 #vm_efi="uefi"
 
-vm_ram="1g"
+vm_package="small1"
 
 # VNC
 vm_vnc_port="0"

--- a/etc/defaults/vm-linux-CentOS-7.3-x86_64.conf
+++ b/etc/defaults/vm-linux-CentOS-7.3-x86_64.conf
@@ -1,11 +1,11 @@
 # don't remove this line:
-vm_profile="CentOS-7-x86_64"
+vm_profile="CentOS-7.3-x86_64"
 vm_os_type="linux"
 iso_vmlinuz_file="/isolinux/vmlinuz"
 iso_initrd_file="/isolinux/initrd.img"
 
 # this is one-string additional info strings in dialogue menu
-long_description="Linux CentOS 7.0"
+long_description="Linux CentOS 7.4"
 
 # custom settings:
 fetch=1
@@ -14,15 +14,15 @@ fetch=1
 grub_boot_cmd="echo -e \"configfile /grub2/grub.cfg\n\" |/usr/bin/lockf -s -t0 /tmp/bhyveload.${jname}.lock grub-bhyve -r hd0,msdos1 -m ${_devicemap} -M ${grubmem} ${jname}"
 grub_iso_cmd="echo -e \"linux ${iso_vmlinuz_file} text\ninitrd ${iso_initrd_file}\nboot\" | /usr/bin/lockf -s -t0 /tmp/bhyveload.${jname}.lock grub-bhyve -r cd0 -m "${_devicemap}" -M ${grubmem} "${jname}""
 
-iso_site="http://mirror.logol.ru/centos/7/isos/x86_64/ \
-http://centos.mirror.far.fi/7/isos/x86_64/ \
-http://mirrors.163.com/centos/7/isos/x86_64/ \
-http://centos.ustc.edu.cn/centos/7/isos/x86_64/ \
-http://mirrors.neusoft.edu.cn/centos/7/isos/x86_64/ \
-http://ftp.funet.fi/pub/mirrors/centos.org/7/isos/x86_64/ \
-http://mirror.lzu.edu.cn/centos/7/isos/x86_64/ \
-http://mirrors.yun-idc.com/centos/7/isos/x86_64/ \
-http://ftp.neowiz.com/centos/7/isos/x86_64/ \
+iso_site="http://mirror.logol.ru/centos/7.3.1611/isos/x86_64/ \
+http://centos.mirror.far.fi/7.3.1611/isos/x86_64/ \
+http://mirrors.163.com/centos/7.3.1611/isos/x86_64/ \
+http://centos.ustc.edu.cn/centos/7.3.1611/isos/x86_64/ \
+http://mirrors.neusoft.edu.cn/centos/7.3.1611/isos/x86_64/ \
+http://ftp.funet.fi/pub/mirrors/centos.org/7.3.1611/isos/x86_64/ \
+http://mirror.lzu.edu.cn/centos/7.3.1611/isos/x86_64/ \
+http://mirrors.yun-idc.com/centos/7.3.1611/isos/x86_64/ \
+http://ftp.neowiz.com/centos/7.3.1611/isos/x86_64/ \
 "
 
 iso_img="CentOS-7-x86_64-Minimal-1611.iso"
@@ -33,11 +33,9 @@ register_iso_as="iso-${vm_profile}"
 
 default_jailname="centos"
 
-imgsize="6g"
 #boot_from_grub=1
 #vm_efi="uefi"
-
-vm_ram="1g"
+vm_package="small1"
 
 # VNC
 vm_vnc_port="0"

--- a/etc/defaults/vm-linux-CoreOS.conf
+++ b/etc/defaults/vm-linux-CoreOS.conf
@@ -25,10 +25,9 @@ register_iso_name="cbsd-iso-${iso_img}"
 register_iso_as="iso-${vm_profile}"
 
 default_jailname="coreos"
-imgsize="6g"
-#boot_from_grub=1
 
-vm_ram="1g"
+#boot_from_grub=1
+vm_package="small1"
 
 # VNC
 vm_vnc_port="0"

--- a/etc/defaults/vm-linux-OracleLinux-7.conf
+++ b/etc/defaults/vm-linux-OracleLinux-7.conf
@@ -29,9 +29,7 @@ register_iso_name="cbsd-iso-${iso_img}"
 register_iso_as="iso-${vm_profile}"
 
 default_jailname="oracle"
-vm_ram="1g"
-
-imgsize="6g"
+vm_package="small1"
 
 # VNC
 vm_vnc_port="0"

--- a/etc/defaults/vm-linux-RancherOS-1.0.3.conf
+++ b/etc/defaults/vm-linux-RancherOS-1.0.3.conf
@@ -24,11 +24,10 @@ register_iso_as="iso-${vm_profile}"
 
 default_jailname="rancher"
 
-imgsize="6g"
 #boot_from_grub=1
 #vm_efi="uefi"
 
-vm_ram="1g"
+vm_package="small1"
 
 # VNC
 vm_vnc_port="0"
@@ -39,4 +38,3 @@ active=0
 
 # Available in ClonOS?
 clonos_active=0
-

--- a/etc/defaults/vm-linux-Tails-3.0.1.conf
+++ b/etc/defaults/vm-linux-Tails-3.0.1.conf
@@ -24,11 +24,10 @@ register_iso_as="iso-${vm_profile}"
 
 default_jailname="tails"
 
-imgsize="6g"
 #boot_from_grub=1
 #vm_efi="uefi"
 
-vm_ram="1g"
+vm_package="small1"
 
 # VNC
 vm_vnc_port="0"
@@ -39,4 +38,3 @@ active=0
 
 # Available in ClonOS?
 clonos_active=0
-

--- a/etc/defaults/vm-linux-fedora-server-25-x86_64.conf
+++ b/etc/defaults/vm-linux-fedora-server-25-x86_64.conf
@@ -17,9 +17,7 @@ register_iso_name="cbsd-iso-Fedora-Server-dvd-x86_64-25-1.3.iso"
 register_iso_as="iso-Fedora-Server-dvd-x86_64-25"
 
 default_jailname="fedora"
-
-imgsize="10g"
-vm_ram="1g"
+vm_package="small1"
 
 # VNC
 vm_vnc_port="0"

--- a/etc/defaults/vm-linux-fedora-server-26-x86_64.conf
+++ b/etc/defaults/vm-linux-fedora-server-26-x86_64.conf
@@ -23,9 +23,7 @@ register_iso_name="cbsd-iso-Fedora-Server-dvd-x86_64-26-1.5.iso"
 register_iso_as="iso-Fedora-Server-dvd-x86_64-26"
 
 default_jailname="fedora"
-
-imgsize="10g"
-vm_ram="1g"
+vm_package="small1"
 
 # VNC
 vm_vnc_port="0"

--- a/etc/defaults/vm-linux-fedora-workstation-24-x86_64.conf
+++ b/etc/defaults/vm-linux-fedora-workstation-24-x86_64.conf
@@ -15,9 +15,7 @@ register_iso_name="cbsd-iso-Fedora-Workstation-Live-x86_64-24-1.2.iso"
 register_iso_as="iso-Fedora-Workstation-Live-x86_64-24"
 
 default_jailname="fedora"
-
-imgsize="10g"
-vm_ram="1g"
+vm_package="small1"
 
 # VNC
 vm_vnc_port="0"

--- a/etc/defaults/vm-linux-opensuse-x86-42.conf
+++ b/etc/defaults/vm-linux-opensuse-x86-42.conf
@@ -30,10 +30,9 @@ register_iso_name="cbsd-iso-${iso_img}"
 register_iso_as="iso-OpenSuSE-x86-42"
 
 default_jailname="opensuse"
-imgsize="8g"
-#boot_from_grub=1
 
-vm_ram="1g"
+#boot_from_grub=1
+vm_package="small1"
 
 # VNC
 vm_vnc_port="0"

--- a/etc/defaults/vm-linux-ubuntuserver-x86-16.04.conf
+++ b/etc/defaults/vm-linux-ubuntuserver-x86-16.04.conf
@@ -33,10 +33,9 @@ register_iso_name="cbsd-iso-${iso_img}"
 register_iso_as="iso-Ubuntu-Server-16.04.3"
 
 default_jailname="ubuntusrv"
-imgsize="8g"
-boot_from_grub=1
 
-vm_ram="1g"
+boot_from_grub=1
+vm_package="small1"
 
 #virtio_type="virtio-blk"
 # on virtio, Debian installer staled/freezed on Detecting HW stage

--- a/etc/defaults/vm-linux-ubuntuserver-x86-17.04.conf
+++ b/etc/defaults/vm-linux-ubuntuserver-x86-17.04.conf
@@ -33,10 +33,9 @@ register_iso_name="cbsd-iso-${iso_img}"
 register_iso_as="iso-Ubuntu-Server-17.04"
 
 default_jailname="ubuntusrv"
-imgsize="8g"
-boot_from_grub=0
 
-vm_ram="1g"
+boot_from_grub=0
+vm_package="small1"
 
 virtio_type="virtio-blk"
 # on virtio, Debian installer staled/freezed on Detecting HW stage

--- a/etc/defaults/vm-openbsd-x86-6.conf
+++ b/etc/defaults/vm-openbsd-x86-6.conf
@@ -24,13 +24,13 @@ vm_hostbridge="amd_hostbridge"     # "amd_" for the AMD hostbridge
 virtio_type="virtio-blk" # "ahci-hd" or "virtio-blk"
 
 default_jailname="openbsd"
-imgsize="2g"
 boot_from_grub=1
-vm_ram="1g"
+
+vm_package="small1"
 
 # VNC
-#vm_vnc_port="0"
-#vm_efi="uefi"
+vm_vnc_port="0"
+vm_efi="uefi"
 
 # disable profile?
 active=1

--- a/etc/defaults/vm-other-Minoca.conf
+++ b/etc/defaults/vm-other-Minoca.conf
@@ -18,9 +18,7 @@ register_iso_as="iso-Minoca"
 iso_extract="tar xfz "
 
 default_jailname="minoca"
-imgsize="4g"
-
-vm_cpus="1"
+vm_package="small1"
 
 #virtio_type="ahci-hd"
 virtio_type="virtio-blk"
@@ -31,7 +29,6 @@ active=0
 # Available in ClonOS?
 clonos_active=0
 
-vm_ram="4g"
 vm_vnc_port="0"
 vm_efi="uefi"
 

--- a/etc/defaults/vm-other-OSX.conf
+++ b/etc/defaults/vm-other-OSX.conf
@@ -12,9 +12,7 @@ iso_img="OSX_10.6.7.iso"
 iso_img_dist=""
 
 default_jailname="osx"
-imgsize="10g"
-
-vm_cpus="4"
+vm_package="small1"
 
 virtio_type="ahci-hd"
 
@@ -28,7 +26,6 @@ clonos_active=0
 register_iso_name="cbsd-iso-${iso_img}"
 register_iso_as="iso-${vm_profile}"
 
-vm_ram="8g"
 vm_vnc_port="0"
 vm_efi="uefi"
 

--- a/etc/defaults/vm-other-ReactOS.conf
+++ b/etc/defaults/vm-other-ReactOS.conf
@@ -14,9 +14,7 @@ iso_img_dist="ReactOS-0.4.3-iso.zip"
 iso_extract="tar xfz "
 
 default_jailname="reactos"
-imgsize="10g"
-
-vm_cpus="2"
+vm_package="small1"
 
 virtio_type="ahci-hd"
 
@@ -30,7 +28,6 @@ active=0
 # Available in ClonOS?
 clonos_active=0
 
-vm_ram="2g"
 vm_vnc_port="0"
 vm_efi="uefi"
 

--- a/etc/defaults/vm-other-SmartOS.conf
+++ b/etc/defaults/vm-other-SmartOS.conf
@@ -14,8 +14,6 @@ iso_img_dist=""
 iso_extract=""
 
 default_jailname="smartos"
-imgsize="10g"
-
 virtio_type="ahci-hd"
 
 # disable profile?
@@ -28,14 +26,12 @@ clonos_active=0
 register_iso_name="cbsd-iso-${iso_img}"
 register_iso_as="iso-${vm_profile}"
 
-
 # VNC
 vm_vnc_port="0"
 vm_efi="uefi"
 
 #vm_console="nmdm"
-vm_ram="2g"
-vm_cpus="1"
+vm_package="small1"
 
 # VirtualBox Area
 virtualbox_ostype="MacOS109_64"

--- a/etc/defaults/vm-other-hackintosh.conf
+++ b/etc/defaults/vm-other-hackintosh.conf
@@ -12,10 +12,6 @@ iso_img="hackintosh.iso"
 iso_img_dist=""
 
 default_jailname="hackintosh"
-imgsize="10g"
-
-vm_cpus="4"
-
 virtio_type="ahci-hd"
 
 # disable profile?
@@ -28,7 +24,7 @@ clonos_active=0
 register_iso_name="cbsd-iso-${iso_img}"
 register_iso_as="iso-${vm_profile}"
 
-vm_ram="8g"
+vm_package="small1"
 vm_vnc_port="0"
 vm_efi="uefi"
 

--- a/etc/defaults/vm-other-solaris-11.conf
+++ b/etc/defaults/vm-other-solaris-11.conf
@@ -17,10 +17,10 @@ register_iso_name="cbsd-iso-${iso_img}"
 register_iso_as="iso-Solaris-11.3"
 
 default_jailname="solaris"
-imgsize="8g"
+
 boot_from_grub=1
 
-vm_ram="1g"
+vm_package="small1"
 
 #virtio_type="virtio-blk"
 virtio_type="ahci-hd"

--- a/etc/defaults/vm-windows-10_86x_64x.conf
+++ b/etc/defaults/vm-windows-10_86x_64x.conf
@@ -12,9 +12,8 @@ iso_img="windows10.iso"
 iso_img_dist=""
 
 default_jailname="windows"
-imgsize="10g"
-
-vm_cpus="1"
+vm_package="small1"
+vm_ram="4g"
 
 virtio_type="ahci-hd"
 #virtio_type="virtio-blk"
@@ -24,8 +23,6 @@ active=1
 
 # Available in ClonOS?
 clonos_active=1
-
-vm_ram="4g"
 
 vm_vnc_port="0"
 vm_efi="uefi"

--- a/etc/defaults/vm-windows-8_86x_64x.conf
+++ b/etc/defaults/vm-windows-8_86x_64x.conf
@@ -12,13 +12,12 @@ iso_img="windows8.iso"
 iso_img_dist=""
 
 default_jailname="windows"
-imgsize="6g"
 
 virtio_type="ahci-hd"
 #virtio_type="virtio-blk"
 
+vm_package="small1"
 vm_ram="4g"
-vm_cpus="1"
 
 vm_vnc_port="0"
 vm_efi="uefi"

--- a/jailctl/blogin
+++ b/jailctl/blogin
@@ -1,5 +1,5 @@
 #!/usr/local/bin/cbsd
-#v10.0.4
+#v11.1.2
 globalconf="${workdir}/cbsd.conf";
 MYARG=""
 MYOPTARG="jname remote inter"
@@ -35,12 +35,50 @@ try_remote()
 	exit 0
 }
 
+login_internal()
+{
+
+	if [ "${vm_efi}" != "none" ]; then
+		if [ -f "${jailsysdir}/${jname}/vnc_port" ]; then
+			echo " *** VM booted in VNC mode. ***"
+			${ECHO} "${MAGENTA}For attach VM console, use: ${GREEN}vncviewer ${vnc_bind}:${vm_port}${NORMAL}"
+			if ! getyesno "Do you want to attach into UEFI console anyway?"; then
+				exit 0
+			fi
+		else
+			echo " *** VM booted in VNC mode. ***"
+			echo "But no ${jailsysdir}/${jname}/vnc_port file"
+			if ! getyesno "Do you want to attach into UEFI console anyway?"; then
+				exit 0
+			fi
+		fi
+	fi
+
+	export TERM=xterm
+	/usr/local/bin/tmux attach-session -t cbsdb-${jname} 2>/dev/null || /usr/local/bin/tmux attach-session -t cbsd-${jname}
+}
+
+
+login_custom()
+{
+	# reset PATH to default
+	export PATH="/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin:/home/oleg/bin"
+	. ${workdir}/jcreate.subr	# for export_bhyve_data_for_external_hook
+	export_bhyve_data_for_external_hook
+	readconf blogin.conf
+	${ECHO} "${MAGENTA}Custom login command: ${GREEN}${login_cmd}${NORMAL}"
+	exec /bin/sh -c "${login_cmd}"
+}
+
+
 . ${jrcconf}
+readconf blogin.conf
+
 [ $? -eq 1 ] && try_remote
 [ "${emulator}" != "bhyve" ] && err 1 "${MAGENTA}Not in bhyve mode${NORMAL}"
-[ "$baserw" = "1" ] && path=$data
+[ "${baserw}" = "1" ] && path=${data}
 
-[ $jid -eq 0 ] && err 1 "Not running"
+[ ${jid} -eq 0 ] && err 1 "Not running"
 
 vm_efi=$( cbsdsql local "SELECT vm_efi FROM bhyve WHERE jname=\"${jname}\"" )
 vnc_bind=$( cbsdsql local "SELECT bhyve_vnc_tcp_bind FROM bhyve WHERE jname=\"${jname}\"" )
@@ -48,19 +86,16 @@ vnc_bind=$( cbsdsql local "SELECT bhyve_vnc_tcp_bind FROM bhyve WHERE jname=\"${
 if [ "${vm_efi}" != "none" ]; then
 	if [ -f "${jailsysdir}/${jname}/vnc_port" ]; then
 		vm_port=$( /bin/cat ${jailsysdir}/${jname}/vnc_port )
-		echo " *** VM booted in VNC mode. ***"
-		${ECHO} "${MAGENTA}For attach VM console, use: ${GREEN}vncviewer ${vnc_bind}:${vm_port}${NORMAL}"
-		if ! getyesno "Do you want to attach into UEFI console anyway?"; then
-			exit 0
-		fi
 	else
-		echo " *** VM booted in VNC mode. ***"
-		echo "But no ${jailsysdir}/${jname}/vnc_port file"
-		if ! getyesno "Do you want to attach into UEFI console anyway?"; then
-			exit 0
-		fi
+		vm_port="0"
 	fi
 fi
 
-export TERM=xterm
-/usr/local/bin/tmux attach-session -t cbsdb-${jname} 2>/dev/null || /usr/local/bin/tmux attach-session -t cbsd-${jname}
+case "${login_cmd}" in
+	internal)
+		login_internal
+		;;
+	*)
+		login_custom
+		;;
+esac

--- a/jailctl/bls
+++ b/jailctl/bls
@@ -139,10 +139,18 @@ show_local()
 	host_hostname="-"
 	path="-"
 	jid="0"
+	vm_ram="-"
+	vm_cpus="-"
+	vm_os_type="-"
+	path="-"
+	status="-"
+	vnc_port="-"
 
 	for J in $( /bin/ls ${jailrcconfdir} ); do
 		jname=""
+		[ ! -r ${jailrcconfdir}/${J} ] && continue
 		. ${jailrcconfdir}/${J}
+
 		[ -z "${jname}" ] && continue
 		populate_output_data "Unregister"
 		${ECHO} ${_status}

--- a/jailctl/bregister
+++ b/jailctl/bregister
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec cbsd jregister $*

--- a/jailctl/bunregister
+++ b/jailctl/bunregister
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec cbsd junregister $*

--- a/jailctl/j2prepare
+++ b/jailctl/j2prepare
@@ -1,14 +1,16 @@
 #!/usr/local/bin/cbsd
-#v10.1.2
+#v11.1.3
 CBSDMODULE="jail"
-MYARG="node jname"
+MYARG="node jname mkdatadir"
 MYOPTARG="verbose sharedfs"
 MYDESC="Prepare remote node for accepting jail via j2slave"
+ADDHELP="mkdatadir - 0 or 1: create data directory. 1 - create, by default\n"
 
 . ${subr}
 . ${strings}
 
 sharedfs=0
+mkdatadir=1
 
 init $*
 
@@ -19,7 +21,6 @@ SECFILE="${workdir}/etc/${jname}.secrets"
 
 . ${jrcconf}
 [ $? -eq 1 ] && err 1 "${MAGENTA}No such jail: ${GREEN}${jname}${NORMAL}"
-[ "${emulator}" = "bhyve" ] && err 1 "${MAGENTA}Not for bhyve mode${NORMAL}"
 
 printf "${MAGENTA}Preparing.${NORMAL}"
 
@@ -36,7 +37,7 @@ RJAILFSTAB="jails-fstab/${jailfstabpref}${jname}"
 
 not_sharedfs_action()
 {
-	jgensecrets jname=${jname} mode=force > $DEBLOG 2>&1
+	jgensecrets jname=${jname} mode=force > ${DEBLOG} 2>&1
 	dot "jgensecrets"
 
 	[ ! -f "${SECFILE}" ] && err 1 "${MAGENTA}No such secrets${NORMAL}"
@@ -44,46 +45,48 @@ not_sharedfs_action()
 	NODEDATA=$( cbsdsql nodes select ip,port,keyfile from nodelist where nodename=\"${node}\" )
 
 	[ -z "${NODEDATA}" ] && err 1 "${MAGENTA}: No such node. Please execute ${GREEN}cbsd add node=${node} ${MAGENTA}first${NORMAL}"
-	sqllist "$NODEDATA" myip myport mykey
+	sqllist "${NODEDATA}" myip myport mykey
 
 	SSHOP="-oBatchMode=yes -oStrictHostKeyChecking=no -oConnectTimeout=5 -q -oPort=${myport} -i ${mykey} ${myip}"
 
-	rexe node=$node cbsd secretsfile jname=$jname mode=off > $DEBLOG 2>&1
+	rexe node=${node} cbsd secretsfile jname=${jname} mode=off > ${DEBLOG} 2>&1
 	dot "rexe"
-	nodescp ${SECFILE} ${node}:etc > $DEBLOG 2>&1
+	nodescp ${SECFILE} ${node}:etc > ${DEBLOG} 2>&1
 	dot "scp_secfile"
 	imgpart mode=pack jname=${jname} part=sysdata out=${tmpdir}/${jname}-sysdata.tgz > ${DEBLOG} 2>&1
 	trap "rm -f ${tmpdir}/${jname}-sysdata.tgz" 0 1 2 3 4
-	nodescp ${tmpdir}/${jname}-sysdata.tgz ${node}:jails-system > $DEBLOG 2>&1
+	nodescp ${tmpdir}/${jname}-sysdata.tgz ${node}:jails-system > ${DEBLOG} 2>&1
 	dot "scp_sysdata"
-	rexe node=$node cbsd secretsfile jname=$jname mode=on > $DEBLOG 2>&1
+	rexe node=${node} cbsd secretsfile jname=${jname} mode=on > ${DEBLOG} 2>&1
 	dot "rexe_2"
 	RDIR="${jname}-data"
-	rexe node=$node cbsd mkdatadir jname=${jname} > $DEBLOG 2>&1
-	dot "rexe_3"
+	if [ "${mkdatadir}" = "1" ]; then
+		rexe node=${node} cbsd mkdatadir jname=${jname} > ${DEBLOG} 2>&1
+		dot "rexe_3"
+	fi
 
 	if [ -f ${JAILFSTAB} ]; then
-		nodescp ${JAILFSTAB} ${node}:${RJAILFSTAB} > $DEBLOG 2>&1
+		nodescp ${JAILFSTAB} ${node}:${RJAILFSTAB} > ${DEBLOG} 2>&1
 		dot "scp fstab"
 	fi
 
 	cbsd rexe node=${node} cbsd imgpart mode=extract jname=jails-system/${jname}-sysdata.tgz part=sysdata out=jails-system > ${DEBLOG} 2>&1
 	dot "rexe_img_extract_sysdata"
 
-	rexe node=$node rm -f jails-system/${jname}-sysdata.tgz > $DEBLOG 2>&1
+	rexe node=${node} rm -f jails-system/${jname}-sysdata.tgz > ${DEBLOG} 2>&1
 	dot "rexe_rm-f-sysdata"
 }
 
 [ ${sharedfs} -eq 0 ] && not_sharedfs_action
 
 jmkrcconf jname=${jname} > ${JAILRCCONF}
-nodescp ${JAILRCCONF} ${node}:${RJAILRCCONF} > $DEBLOG 2>&1
+nodescp ${JAILRCCONF} ${node}:${RJAILRCCONF} > ${DEBLOG} 2>&1
 dot "scp rcconf"
-rm -f ${JAILRCCONF}
+/bin/rm -f ${JAILRCCONF}
 
-rexe node=$node cbsd jrsyncconf jname=${jname} > $DEBLOG 2>&1
+rexe node=${node} /usr/local/bin/cbsd jrsyncconf jname=${jname} > ${DEBLOG} 2>&1
 dot "rexe_jrsyncconf"
 
-rexe node=$node cbsd replacewdir old=${workdir} file0=${RJAILRCCONF} file1=${RJAILFSTAB} > $DEBLOG 2>&1
+rexe node=${node} cbsd replacewdir old=${workdir} file0=${RJAILRCCONF} file1=${RJAILFSTAB} > ${DEBLOG} 2>&1
 dot "rexe_4"
 err 0 "${GREEN}ok${NORMAL}"

--- a/jailctl/jls
+++ b/jailctl/jls
@@ -95,6 +95,7 @@ show_local()
 
 	for J in $( /bin/ls ${jailrcconfdir} ); do
 		jname=""
+		[ ! -r ${jailrcconfdir}/${J} ] && continue
 		. ${jailrcconfdir}/${J}
 		[ -z "${jname}" ] && continue
 		populate_output_data "Unregister"

--- a/jailctl/jregister
+++ b/jailctl/jregister
@@ -58,6 +58,13 @@ insert_full()
 	cbsdsql local "INSERT INTO jails ( ${_sqlparam} ) VALUES ( ${_sqlvalue} )"
 	[ -f "${LIMITS}" ] && jmkrctlconf jname=${jname} type=rctl mode=tosql file=${LIMITS}
 	[ -f "${LIMITS}.extra" ] && jmkrctlconf jname=${jname} type=extra mode=tosql file=${LIMITS}.extra
+
+	if [ "${emulator}" = "bhyve" ]; then
+		local MEDIASQL="${jailsysdir}/${jname}/media.sql"
+		if [ -r "${MEDIASQL}" ]; then
+			/usr/local/bin/sqlite3 ${dbdir}/storage_media.sqlite < ${MEDIASQL}
+		fi
+	fi
 }
 
 insert_bhyve()

--- a/jailctl/junregister
+++ b/jailctl/junregister
@@ -1,5 +1,5 @@
 #!/usr/local/bin/cbsd
-#v10.0.4
+#v11.1.3
 MYARG="jname"
 MYOPTARG="dbfile mode rcfile"
 MYDESC="Register jail records to SQLite from ASCii config or re-populate ASCii config from SQLite"
@@ -21,8 +21,14 @@ init $*
 delete_full()
 {
 	local LIMITS="${jailsysdir}/${jname}/jail.limits"
+	local MEDIASQL="${jailsysdir}/${jname}/media.sql"
 
 	[ -z "${jname}" ] && return 0
+
+	# export media data to ascii file
+	media mode=dump jname=${jname} > ${MEDIASQL}
+	cbsdsql storage_media DELETE FROM media WHERE jname=\"${jname}\" 2>/dev/null
+
 	jmkrctlconf jname=${jname} type=rctl mode=tofile file=${LIMITS}
 	jmkrctlconf jname=${jname} type=extra mode=tofile file=${LIMITS}.extra
 
@@ -30,11 +36,6 @@ delete_full()
 	cbsdsql local DELETE FROM rctl WHERE jname=\"${jname}\" 2>/dev/null
 	cbsdsql local DELETE FROM bhyve WHERE jname=\"${jname}\" 2>/dev/null
 	cbsdsql local DELETE FROM virtualbox WHERE jname=\"${jname}\" 2>/dev/null
-	cbsdsql ${jailsysdir}/${jname}/local.sqlite DELETE FROM bhyvedsk WHERE jname=\"${jname}\" 2>/dev/null
-	cbsdsql ${jailsysdir}/${jname}/local.sqlite DELETE FROM bhyvenic WHERE jname=\"${jname}\" 2>/dev/null
-
-	cbsdsql ${jailsysdir}/${jname}/local.sqlite DELETE FROM xendsk WHERE jname=\"${jname}\" 2>/dev/null
-	cbsdsql ${jailsysdir}/${jname}/local.sqlite DELETE FROM xennic WHERE jname=\"${jname}\" 2>/dev/null
 
 	cbsdsql local DELETE FROM virtualboxdsk WHERE jname=\"${jname}\" 2>/dev/null
 	cbsdsql local DELETE FROM virtualboxnic WHERE jname=\"${jname}\" 2>/dev/null
@@ -47,5 +48,5 @@ else
 	JAILRCCONF="${rcfile}"
 fi
 
-echo jmkrcconf jname=${jname} > ${JAILRCCONF}
+jmkrcconf jname=${jname} > ${JAILRCCONF}
 delete_full

--- a/jcreate.subr
+++ b/jcreate.subr
@@ -67,11 +67,19 @@ external_exec_script()
 	[ -d "${data}/tmp/${_dir}" ] && /bin/rm -rf "${data}/tmp/${_dir}"
 	/bin/cp -a "${jailsysdir}/${jname}/${_dir}" ${data}/tmp/${_dir}
 
+	local CBSDPATH="${PATH}"
+	# reset CBSD PATH
+	export PATH="/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin"
+
 	/usr/bin/find "${data}/tmp/${_dir}" \( -type l -or -type f \) -and \( -perm +111 \) -depth 1 -maxdepth 1 -exec /usr/bin/basename {} \; | while read _file; do
 		${ECHO} "${MAGENTA}Execute script: ${GREEN}${_file}${NORMAL}"
 		jexec jname="${jname}" /tmp/${_dir}/${_file}
 	done
 	/bin/rm -rf "${data}/tmp/${_dir}"
+
+	# restore CBSD PATH
+	export PATH="${CBSDPATH}"
+
 }
 
 # users custom stop for executing in master host
@@ -89,10 +97,17 @@ external_exec_master_script()
 	[ ! -d "${_srcdir}" ] && return 0
 	[ -z "$( /bin/ls ${_srcdir}/ )" ] && return 0
 
+	local CBSDPATH="${PATH}"
+	# reset CBSD PATH
+	export PATH="/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin"
+
 	/usr/bin/find "${_srcdir}" \( -type l -or -type f \) -and \( -perm +111 \) -depth 1 -maxdepth 1 -exec /usr/bin/basename {} \; |while read _file; do
 		${ECHO} "${MAGENTA}Execute master script: ${GREEN}${_file}${NORMAL}"
 		${_srcdir}/${_file}
 	done
+
+	# restore CBSD PATH
+	export PATH="${CBSDPATH}"
 }
 
 # users custom stop script
@@ -109,11 +124,18 @@ external_exec_script()
 	[ -d "${data}/tmp/${_dir}" ] && rm -rf "${data}/tmp/${_dir}"
 	/bin/cp -a "${jailsysdir}/${jname}/${_dir}" ${data}/tmp/${_dir}
 
+	local CBSDPATH="${PATH}"
+	# reset CBSD PATH
+	export PATH="/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin"
+
 	/usr/bin/find "${data}/tmp/${_dir}" \( -type l -or -type f \) -and \( -perm +111 \) -depth 1 -maxdepth 1 -exec /usr/bin/basename {} \; | while read _file; do
 		${ECHO} "${MAGENTA}Execute script: ${GREEN}${_file}${NORMAL}"
 		jexec jname="${jname}" /tmp/${_dir}/${_file}
 	done
+
 	/bin/rm -rf "${data}/tmp/${_dir}"
+	# restore CBSD PATH
+	export PATH="${CBSDPATH}"
 }
 
 # users custom stop for executing in master host
@@ -130,10 +152,17 @@ external_exec_master_script()
 	[ ! -d "${_srcdir}" ] && return 0
 	[ -z "$( /bin/ls ${_srcdir}/ )" ] && return 0
 
+	local CBSDPATH="${PATH}"
+	# reset CBSD PATH
+	export PATH="/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin"
+
 	/usr/bin/find "${_srcdir}" \( -type l -or -type f \) -and \( -perm +111 \) -depth 1 -maxdepth 1 -exec /usr/bin/basename {} \; |while read _file; do
 		${ECHO} "${MAGENTA}Execute master script: ${GREEN}${_file}${NORMAL}"
 		${_srcdir}/${_file}
 	done
+
+	# restore CBSD PATH
+	export PATH="${CBSDPATH}"
 }
 
 exec_master_prestop()
@@ -141,16 +170,30 @@ exec_master_prestop()
 #	eval CMD=\${exec_master_prestop${i}}
 	eval CMD=\${exec_master_prestop}
 	[ -z "${CMD}" -o "${CMD}" = "0" ] && return 0
+
+	local CBSDPATH="${PATH}"
+	# reset CBSD PATH
+	export PATH="/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin"
+
 	${ECHO} "${MAGENTA}${jname} Master exec prestop: ${GREEN}${CMD}${NORMAL}"
 	${CMD}
+	# restore CBSD PATH
+	export PATH="${CBSDPATH}"
 }
 
 exec_prestop()
 {
 	eval CMD=\${exec_prestop}
 	[ -z "${CMD}" -o "${CMD}" = "0" ] && return 0
+
+	local CBSDPATH="${PATH}"
+	# reset CBSD PATH
+	export PATH="/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin"
+
 	${ECHO} "${MAGENTA}${jname} exec exec_prestop: ${GREEN}${CMD}${NORMAL}"
 	/usr/sbin/chroot ${path} ${CMD}
+	# restore CBSD PATH
+	export PATH="${CBSDPATH}"
 }
 
 
@@ -158,39 +201,74 @@ exec_master_poststop()
 {
 	eval CMD=\${exec_master_poststop}
 	[ -z "${CMD}" -o "${CMD}" = "0" ] && return 0
+
+	local CBSDPATH="${PATH}"
+	# reset CBSD PATH
+	export PATH="/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin"
+
 	${ECHO} "${MAGENTA}${jname} Master exec afterstop: ${GREEN}${CMD}${NORMAL}"
 	${CMD}
+	# restore CBSD PATH
+	export PATH="${CBSDPATH}"
 }
 
 exec_poststop()
 {
 	eval CMD=\${exec_poststop}
 	[ -z "${CMD}" -o "${CMD}" = "0" ] && return 0
+
+	local CBSDPATH="${PATH}"
+	# reset CBSD PATH
+	export PATH="/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin"
+
 	${ECHO} "${MAGENTA}${jname} exec exec_poststop: ${GREEN}${CMD}${NORMAL}"
 	chroot ${path} ${CMD}
+	# restore CBSD PATH
+	export PATH="${CBSDPATH}"
 	i=$((i + 1))
 }
+
 exec_master_poststart()
 {
 	eval CMD=\${exec_master_poststart}
 	[ -z "${CMD}" -o "${CMD}" = "0" ] && return 0
+
+	local CBSDPATH="${PATH}"
+	# reset CBSD PATH
+	export PATH="/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin"
+
 	${ECHO} "${MAGENTA}${jname} Master exec afterstart: ${GREEN}${CMD}${NORMAL}"
 	${CMD}
+	# restore CBSD PATH
+	export PATH="${CBSDPATH}"
 }
 
 exec_poststart()
 {
 	eval CMD=\${exec_poststart}
 	[ -z "${CMD}" -o "${CMD}" = "0" ] && return 0
+
+	local CBSDPATH="${PATH}"
+	# reset CBSD PATH
+	export PATH="/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin"
+
 	${ECHO} "${MAGENTA}${jname} exec exec_poststart: ${GREEN}${CMD}${NORMAL}"
 	jexec jname=${jname} ${CMD}
+	# restore CBSD PATH
+	export PATH="${CBSDPATH}"
 }
 
 exec_cbsdjail_first_boot()
 {
 	if [ -f ${path}/etc/rc.cbsdjail_first_boot ]; then
+		local CBSDPATH="${PATH}"
+		# reset CBSD PATH
+		export PATH="/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin"
+
 		jexec jname=${jname} /bin/sh /etc/rc.cbsdjail_first_boot
 		rm -f ${path}/etc/rc.cbsdjail_first_boot
+		# restore CBSD PATH
+		export PATH="${CBSDPATH}"
 	fi
 }
 
@@ -198,16 +276,30 @@ exec_master_prestart()
 {
 	eval CMD=\${exec_master_prestart}
 	[ -z "${CMD}" -o "${CMD}" = "0" ] && return 0
+
+	local CBSDPATH="${PATH}"
+	# reset CBSD PATH
+	export PATH=/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin
+
 	${ECHO} "${MAGENTA}${jname} master exec prestart: ${GREEN}${CMD}${NORMAL}"
 	${CMD}
+	# restore CBSD PATH
+	export PATH="${CBSDPATH}"
 }
 
 exec_prestart()
 {
 	eval CMD=\${exec_prestart}
 	[ -z "${CMD}" -o "${CMD}" = "0" ] && return 0
+
+	local CBSDPATH="${PATH}"
+	# reset CBSD PATH
+	export PATH="/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin"
+
 	${ECHO} "${MAGENTA}${jname} exec exec_prestart: ${GREEN}${CMD}${NORMAL}"
 	jexec jname=${jname} ${CMD}
+	# restore CBSD PATH
+	export PATH="${CBSDPATH}"
 }
 
 export_bhyve_data_for_external_hook()
@@ -217,7 +309,7 @@ export_bhyve_data_for_external_hook()
 	# export variables for external hooks
 	export jname=${jname}
 
-	for _i in ${JARG} ${MYCOL}; do
+	for _i in ${JARG} ${MYCOL} ipv4_first_public ipv4_first_private ipv4_first ipv6_first_public ipv6_first_private ipv6_first; do
 		T=
 		eval T="\$$_i"
 		export ${_i}="${T}"
@@ -243,8 +335,9 @@ export_bhyve_data_for_external_hook()
 export_jail_data_for_external_hook()
 {
 	# export variables for external hooks
+	# todo: first_ipv4_addr + first_ipv6_addr
 	export jname=${jname}
-	for _i in ${JARG}; do
+	for _i in ${JARG} ipv4_first_public ipv4_first_private ipv4_first ipv6_first_public ipv6_first_private ipv6_first; do
 		T=
 		eval T="\$$_i"
 		export ${_i}="${T}"

--- a/nc.subr
+++ b/nc.subr
@@ -125,10 +125,13 @@ init() {
 # Show $1 strings and get answer in infinity loop
 # return 0 when YES/1 and 1 when not
 # return 3 if not interactive ($inter=0) (or INTER=0 env exist)
+# if ALWAYS_YES=1 and inter=0, always return 0
+# if ALWAYS_NO=1 and inter=0, always return 1
 getyesno()
 {
 	if [ "${inter}" = "0" -o "${INTER}" = "0" ]; then
 		[ "${ALWAYS_YES}" = "1" ] && return 0
+		[ "${ALWAYS_NO}" = "1" ] && return 1
 		return 3
 	fi
 
@@ -192,12 +195,30 @@ ipwmask()
 
 # parse ip4_addr, check ip, remove commas
 # detect when IP6 in list and set flags for sleep
+# export variables:
+#   ipv4_first_public
+#   ipv4_first_private
+#   ipv4_first
+#   ipv6_first_public
+#   ipv6_first_private
+#   ipv6_first
 geniplist()
 {
 	local I ST a
 	[ -z "${1}" ] && return 0
 	[ ! -f "${distdir}/tools.subr" ] && err 1 "No such tools.subr"
 	. ${distdir}/tools.subr
+
+	local private_net="10.0.0.0/8 172.16.0.0/12 192.168.0.0/16"
+	local pnet NC_RANGE INNET res
+
+	# init global exported variables
+	ipv4_first_public=
+	ipv4_first_private=
+	ipv4_first=
+	ipv6_first_public=
+	ipv6_first_private=
+	ipv6_first=
 
 	HAVE_IPV6=0
 	multiips=$@
@@ -208,13 +229,32 @@ geniplist()
 
 	for a in ${I}; do
 		# Identify type {inet,inet6}.
-		iptype $a
+		iptype ${a}
 		case $? in
 			0)
 				echo "IP ${a} not identified"
 				continue
 			;;
+			1)
+				[ -z "${ipv4_first}" ] && ipv4_first="${IWM}"	# IWM from iptype
+				INNET=0	# count of coincidence in private network
+				if [ -z "${ipv4_first_private}" -o -z "${ip4_first_public}" ]; then
+					for pnet in ${private_net}; do
+						NC_RANGE=$( /bin/echo ${pnet} |/usr/bin/tr "/" " " )
+						netmask ${NC_RANGE} ${IWM} > /dev/null 2>&1
+						res=$?
+						if [ ${res} -eq 1 ]; then
+							INNET=$(( INNET + 1 ))
+						fi
+					done
+				fi
+
+				[ -z "${ipv4_first_private}" -a ${INNET} -ne 0 ] && ipv4_first_private="${IWM}"
+				[ -z "${ipv4_first_public}" -a ${INNET} -eq 0 ] && ipv4_first_public="${IWM}"
+
+				;;
 			2)
+				[ -z "${ipv6_first}" ] && ipv6_first="${IWM}"	# IWM from iptype
 				HAVE_IPV6=1
 			;;
 		esac

--- a/nodectl/node
+++ b/nodectl/node
@@ -1,8 +1,8 @@
 #!/usr/local/bin/cbsd
-#v11.0.0
+#v11.1.3
 CBSDMODULE="node"
 MYARG="mode"
-MYOPTARG="node port rootkeyfile pw header allinfo"
+MYOPTARG="node port rootkeyfile pw header allinfo display"
 MYDESC="Manipulate or show information for remote nodes"
 ADDHELP="mode = add, remove, list, status\n\
 node = remote node ip or fqdn\n\
@@ -11,6 +11,7 @@ rootkeyfile = path to id_rsa for root access\n\
 pw = password of cbsd user from remote node\n\
 header = print header in node list\n\
 allinfo = 1 (default) show all info for nodelist, 0 - only nodename\n\
+display= list by comma for column. Default: nodename,ip,port,keyfile,status,idle\n\
 mode=show - show details about node\n"
 
 EXTHELP="wf_node.html"
@@ -21,6 +22,20 @@ EXTHELP="wf_node.html"
 
 readconf node.conf
 init $*
+
+[ -z "${display}" ] && display="nodename,ip,port,keyfile,status,idle"
+
+#remove commas for loop action on header
+mydisplay=$(echo ${display} |/usr/bin/tr ',' '  ')
+
+# upper for header
+myheader=$(echo ${mydisplay} |/usr/bin/tr '[:lower:]' '[:upper:]')
+
+show_header()
+{
+	local _header="${BOLD}${myheader}${NORMAL}"
+	[ ${header} -ne 0 ] && $ECHO ${_header}
+}
 
 getpw()
 {
@@ -177,21 +192,36 @@ nodedel()
 
 show_nodes()
 {
+	OIFS=${IFS}
 	local sqldelimer IFS
 
 	if [ ${allinfo} -eq 0 ]; then
 		cbsdsql nodes SELECT nodename FROM nodelist
 	else
-		[ ${header} -eq 1 ] && ${ECHO} "${BOLD}NODENAME IP PORT KEYFILE STATUS IDLE${NORMAL}"
+		show_header
 		sqldelimer="|"
 		IFS="|"
-		cbsdsql nodes SELECT nodename,ip,port,keyfile,idle FROM nodelist |while read _nodename _ip _port _keyfile _idle; do
-			local IFS=" "
-			conv_idle
-			printf "${NORMAL}" # for column sort
-			printf "${_nodename} ${_ip} ${_port} ${_keyfile} ${_nodestatus} ${_idle}"
-			printf "\n"
-			local IFS="|"
+		cbsdsql nodes SELECT nodename,ip,port,keyfile,idle FROM nodelist |while read nodename ip port keyfile idle; do
+			IFS=${OIFS}
+
+			conv_idle "${idle}"
+
+			for _i in ${mydisplay}; do
+				_val=""
+
+				eval _val="\$$_i"
+				[ -z "${_val}" ] && _val="-"
+
+				if [ -z "${_status}" ]; then
+					_status="${NORMAL}${_val}"
+				else
+					_status="${_status} ${_val}"
+				fi
+			done
+
+			${ECHO} ${_status}
+			IFS="|"
+			_status=
 		done
 	fi
 	unset sqldelimer

--- a/nodes.subr
+++ b/nodes.subr
@@ -38,24 +38,27 @@ check_locktime()
 }
 
 
-# _idle must be set
+# idle must be set (or specified via $1 )
+# $ip (of nodes) must be set
 conv_idle()
 {
 	local _res
 
-	_nodestatus="Disconnected" # default state
+	status="Disconnected" # default state
 
-	[ -z "${_idle}" ] && return 1
+	[ -n "${1}" ] && idle="${1}"
+
+	[ -z "${idle}" ] && return 1
 
 	if [ ${sqlreplica} -eq 1 ]; then
-		_res=$( check_locktime ${ftmpdir}/shmux_${_ip}.lock )
-		[ $? -eq 0 ] && _nodestatus="Connected" && _idle=${_res} && return 0
+		_res=$( check_locktime ${ftmpdir}/shmux_${ip}.lock )
+		[ $? -eq 0 ] && status="Connected" && idle=${_res} && return 0
 	fi
 
-	idle_time=$( /bin/date -j -f "%Y-%m-%d %H:%M:%S" "${_idle}" "+%s" )
+	idle_time=$( /bin/date -j -f "%Y-%m-%d %H:%M:%S" "${idle}" "+%s" )
 
 	_res=$(( ( curtime - idle_time ) / 60 ))
-	_idle="${_res}"
+	idle="${_res}"
 }
 
 # return $node as selected node by id or name from list

--- a/settings-tui.subr
+++ b/settings-tui.subr
@@ -63,6 +63,7 @@ GET_HOSTBRIDGE_MSG="Hostbridge for VMs, eg: hostbridge or amd_hostbridge"
 GET_ALLOW_SYSVIPC_MSG="Select SYSVIPC behaviour"
 GET_GUESTFS_MSG="Choose FS for boot image"
 GET_EFI_MSG="Choose UEFI firmware"
+GET_VM_PACKAGE_MSG="Choose package name"
 GET_CONSOLE_MSG="Choose default console"
 GET_ISOPATH_MSG="Path to ISO image in srcdir/iso, eg: release.iso. 0 - for default img_iso"
 GET_VM_ISOPATH_MSG="Select available/registered ISO"
@@ -1377,6 +1378,53 @@ get_construct_vm_efi()
 	return ${retval}
 }
 
+# update vm_\* values according to $vm_package data
+# if $1 - "force", all variables will be overwrited
+#  otherwise, assign variables only vm_\* is empty
+# $vm_package variables must be set
+apply_vm_package()
+{
+	[ -z "${vm_package}" ] && return 0
+	[ "${1}" = "force" ] && unset vm_cpus vm_ram imgsize
+
+	[ -z "${vm_cpus}" ] && vm_cpus=$( cbsdsql local SELECT pkg_vm_cpus FROM vmpackages WHERE name=\"${vm_package}\" )
+	[ -z "${vm_ram}" ] && vm_ram=$( cbsdsql local SELECT pkg_vm_ram FROM vmpackages WHERE name=\"${vm_package}\" )
+	[ -z "${imgsize}" ] && imgsize=$( cbsdsql local SELECT pkg_vm_disk FROM vmpackages WHERE name=\"${vm_package}\" )
+
+	return 0
+}
+
+# form for $vm_package
+get_construct_vm_package()
+{
+	local _input _res
+
+	local title="${GET_VM_PACKAGE_MSG}"
+	local defaultitem="${vm_package}"
+
+	local sqldelimer=" "
+
+	local menu_list=$( cbsdsql local SELECT name,pkg_vm_cpus,pkg_vm_ram,pkg_vm_disk FROM vmpackages | while read name pkg_vm_cpus pkg_vm_ram pkg_vm_disk; do
+		echo "'${name}' '[${mark}] name=${name} CPU=${pkg_vm_cpus} RAM=${pkg_vm_ram} DISK=${pkg_vm_disk}'  'description'"
+	done ) || err 1 "${MAGENTA}Error while create packages map${NORMAL}"
+
+	cbsd_menubox
+	retval=$?
+
+	case $retval in
+		${DIALOG_OK})
+			[ -n "${mtag}" ] && vm_package="${mtag}"
+			apply_vm_package force
+			;;
+		*)
+			;;
+	esac
+
+	return ${retval}
+}
+
+
+
 # form for $vm_console
 get_construct_vm_console()
 {
@@ -1427,7 +1475,8 @@ get_construct_vm_os_type()
 	case $retval in
 		${DIALOG_OK})
 			[ -n "${mtag}" ] && vm_os_type="${mtag}"
-			unset vm_os_profile jname imgsize
+			unset vm_os_profile jname imgsize vm_ram vm_cpus
+			apply_vm_package
 			;;
 		*)
 			;;
@@ -1535,8 +1584,10 @@ get_construct_vm_os_profile()
 			[ -z "${_myfile}" ] && return 0
 
 			if [ -f "${_myfile}" ]; then
+				unset imgsize vm_ram vm_cpus
 				. ${_myfile}
 				global_profile_file="${_myfile}"
+				apply_vm_package
 			fi
 			;;
 		*)

--- a/share/bsdconfig/cbsd/node
+++ b/share/bsdconfig/cbsd/node
@@ -29,12 +29,12 @@ dialog_menu_main()
 	local i=1
 	local num
 
-	eval $( cbsdsql nodes SELECT nodename,ip,idle FROM nodelist | while read _nodename _ip _idle; do
+	eval $( cbsdsql nodes SELECT nodename,ip,idle FROM nodelist | while read _nodename ip idle; do
 		echo "local node${i}_name=\"${_nodename}\""
-		echo "local node${i}_ip=\"${_ip}\""
+		echo "local node${i}_ip=\"${ip}\""
 
 		conv_idle
-		echo "local node${i}_status=\"${_nodestatus}\""
+		echo "local node${i}_status=\"${status}\""
 		i=$(( i + 1 ))
 	done )
 

--- a/share/local-vmpackages.schema
+++ b/share/local-vmpackages.schema
@@ -1,9 +1,13 @@
-MYCOL="name description pkg_vm_ram pkg_vm_disk"
+MYCOL="name description pkg_vm_ram pkg_vm_disk pkg_vm_cpus owner timestamp"
 
 name="TEXT DEFAULT NULL UNIQUE PRIMARY KEY"
 description="TEXT DEFAULT NULL"
 pkg_vm_ram="integer default 0"
 pkg_vm_disk="integer default 0"
+pkg_vm_cpus="integer default 1"
+
+owner="text default 0"
+timestamp="TIMESTAMP DATE DEFAULT (datetime('now','localtime'))"
 
 INITDB=""
 CONSTRAINT=""

--- a/sudoexec/bremove
+++ b/sudoexec/bremove
@@ -1,5 +1,5 @@
 #!/usr/local/bin/cbsd
-#v11.1.0
+#v11.1.2
 globalconf="${workdir}/cbsd.conf";
 MYARG=""
 MYOPTARG="jname inter"

--- a/sudoexec/bstart
+++ b/sudoexec/bstart
@@ -552,8 +552,31 @@ readconf ${default_profile}
 [ -z "${vm_ram}" -o -z "${vm_cpus}" -o -z "${vm_os_type}" ] && err 1 "${MAGENTA}Parameter is mandatory: ${GREEN}vm_ram, vm_cpus, vm_os_type${NORMAL}"
 [ "${vm_os_type}" != "freebsd" ] && init_grubcheck
 # hardcoded first disk path from SQL. Todo: mark bootable disk(s)
+
 MDFILE=$( cbsdsql ${jailsysdir}/${jname}/local.sqlite SELECT dsk_path FROM bhyvedsk WHERE jname=\"${jname}\" AND dsk_type=\"vhd\" LIMIT 1 2>/dev/null )
-[ ! -f "${data}/${MDFILE}" -a ! -h "${data}/${MDFILE}" ] && ${ECHO} "${MAGENTA}No such ${data}/${MDFILE} but mdsize flags is not null. Skip${NORMAL}" && continue
+
+[ -z "${MDFILE}" ] && ${ECHO} "${MAGENTA}Warning: no any storage device found for this VM${NORMAL}"
+
+if [ ! -f "${data}/${MDFILE}" -a ! -h "${data}/${MDFILE}" ]; then
+	${ECHO} "${MAGENTA}No such ${data}/${MDFILE} but mdsize flags is not null.${NORMAL}"
+
+	# if zfsfeat=1, try scan for zvol
+	[ "${zfsfeat}" != "1" ] && break
+
+	readconf zfs.conf
+	. $zfstool
+	DATA=$( /sbin/zfs get -Ho value name ${jaildatadir} 2>/dev/null )
+
+	[ -z "${DATA}" ] && break
+
+	for lunname in $( /usr/bin/seq 0 10 ); do
+		if [ -r /dev/zvol/${DATA}/bcbsd-${jname}-dsk${lunname}.vhd ]; then
+			/bin/ln -sf /dev/zvol/${DATA}/bcbsd-${jname}-dsk${lunname}.vhd ${data}/dsk${lunname}.vhd
+			${ECHO} "${MAGENTA}Found zvol and create symlink: ${data}/dsk${lunname}.vhd -> ${DATA}/bcbsd-${jname}-dsk${lunname}.vhd"
+		fi
+	done
+fi
+
 
 # export variables for external hooks
 export jname=${jname}

--- a/sudoexec/jlogin
+++ b/sudoexec/jlogin
@@ -1,5 +1,5 @@
 #!/usr/local/bin/cbsd
-#v10.1.2
+#v11.1.2
 MYARG=""
 MYOPTARG="jname remote inter src_session"
 MYDESC="Exec login into jail"
@@ -60,12 +60,82 @@ init_tmux()
 	# no tmux here
 	tmux_login=0
 	return 0
-
 }
 
-[ -z "$jname" ] && jname=$1
-[ -z "$jname" ] && select_jail_by_list -s "List of online jail" -a "On" -r ${sqlreplica}
-[ -z "$jname" ] && err 1 "${MAGENTA}Please specify jname as argument${NORMAL}"
+
+login_internal()
+{
+	#rctl/limits area
+	. ${workdir}/rctl.subr
+
+	nice=$( cbsdsql local SELECT nice FROM rctl WHERE jname=\"${jname}\" 2>/dev/null )
+	[ -z "${nice}" ] && nice="0"
+
+	if [ ${exec_fib} -eq 0 ]; then
+		SETFIB=""
+	else
+		SETFIB="setfib ${exec_fib}"
+	fi
+
+	if [ "${cpuset}" = "0" ]; then
+		CPUSET=""
+	else
+		CPUSET="cpuset -c -l ${cpuset}"
+	fi
+
+	case "${ver}" in
+		"empty")
+			# is linux?
+			if [ -f "${data}/bin/bash" ]; then
+				LOGIN_STR="/bin/bash"
+			elif [ -f "${data}/bin/sh" ]; then
+				LOGIN_STR="/bin/sh" ];
+			else
+				err 1 "${MAGENTA}Unknown environment, unable to login${NORMAL}"
+			fi
+			;;
+		*)
+			if [ "${emulator}" != "jail" -a -n "${emulator}" ]; then
+				. ${workdir}/emulator.subr
+				init_usermode_emul
+				LOGIN_STR="/bin/${emulator} /usr/bin/login -f root"
+			else
+				LOGIN_STR="/usr/bin/login -f root"
+			fi
+			;;
+	esac
+
+	jexec="/usr/bin/nice -n ${nice} ${SETFIB} ${CPUSET} /usr/sbin/jexec ${jid} ${LOGIN_STR}"
+
+	init_tmux
+
+	if [ $tmux_login -eq 1 ]; then
+		${tmuxcmd} list-sessions | ${GREP_CMD} -qwF "${session_name}:"
+		if [ $? -eq 1 ]; then
+			${tmuxcmd} new -s "${session_name}" "eval ${jexec}"
+		else
+			${tmuxcmd} attach-session -t "${session_name}"
+		fi
+	else
+		eval ${jexec}
+	fi
+}
+
+login_custom()
+{
+	# reset PATH to default
+	export PATH="/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin:/home/oleg/bin"
+	. ${workdir}/jcreate.subr	# for export_jail_data_for_external_hook
+	export_jail_data_for_external_hook
+	readconf jlogin.conf
+	${ECHO} "${MAGENTA}Custom login command: ${GREEN}${login_cmd}${NORMAL}"
+	exec /bin/sh -c "${login_cmd}"
+}
+
+
+[ -z "${jname}" ] && jname=$1
+[ -z "${jname}" ] && select_jail_by_list -s "List of online jail" -a "On" -r ${sqlreplica}
+[ -z "${jname}" ] && err 1 "${MAGENTA}Please specify jname as argument${NORMAL}"
 [ -z "${remote}" ] && remote=0
 
 validate_jname ${jname}
@@ -75,60 +145,16 @@ validate_jname ${jname}
 [ $? -eq 1 ] && try_remote
 [ "${emulator}" = "bhyve" ] && err 1 "${MAGENTA}For bhyve jail use: ${GREEN}cbsd blogin=${jname} ${MAGENTA}instead${NORMAL}"
 [ "${baserw}" = "1" ] && path=${data}
-[ $jid -eq 0 ] && err 1 "Not running"
+[ ${jid} -eq 0 ] && err 1 "Not running"
 
-#rctl/limits area
-. ${workdir}/rctl.subr
+readconf jlogin.conf
 
-nice=$( cbsdsql local SELECT nice FROM rctl WHERE jname=\"${jname}\" 2>/dev/null )
-[ -z "${nice}" ] && nice="0"
-
-if [ ${exec_fib} -eq 0 ]; then
-	SETFIB=""
-else
-	SETFIB="setfib ${exec_fib}"
-fi
-
-if [ "${cpuset}" = "0" ]; then
-	CPUSET=""
-else
-	CPUSET="cpuset -c -l ${cpuset}"
-fi
-
-
-case "${ver}" in
-	"empty")
-		# is linux?
-		if [ -f "${data}/bin/bash" ]; then
-			LOGIN_STR="/bin/bash"
-		elif [ -f "${data}/bin/sh" ]; then
-			LOGIN_STR="/bin/sh" ];
-		else
-			err 1 "${MAGENTA}Unknown environment, unable to login${NORMAL}"
-		fi
+case "${login_cmd}" in
+	internal)
+		login_internal
 		;;
 	*)
-		if [ "${emulator}" != "jail" -a -n "${emulator}" ]; then
-			. ${workdir}/emulator.subr
-			init_usermode_emul
-			LOGIN_STR="/bin/${emulator} /usr/bin/login -f root"
-		else
-			LOGIN_STR="/usr/bin/login -f root"
-		fi
+		login_custom
 		;;
 esac
 
-jexec="/usr/bin/nice -n ${nice} ${SETFIB} ${CPUSET} /usr/sbin/jexec ${jid} ${LOGIN_STR}"
-
-init_tmux
-
-if [ $tmux_login -eq 1 ]; then
-	${tmuxcmd} list-sessions | ${GREP_CMD} -qwF "${session_name}:"
-	if [ $? -eq 1 ]; then
-		${tmuxcmd} new -s "${session_name}" "eval ${jexec}"
-	else
-		${tmuxcmd} attach-session -t "${session_name}"
-	fi
-else
-	eval ${jexec}
-fi

--- a/sudoexec/jstart
+++ b/sudoexec/jstart
@@ -50,22 +50,37 @@ exec_master_poststart()
 {
 	eval CMD=\${exec_master_poststart}
 	[ -z "${CMD}" -o "${CMD}" = "0" ] && return 0
+	local CBSDPATH="${PATH}"
+	# reset CBSD PATH
+	export PATH="/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin"
 	${ECHO} "${MAGENTA}${jname} Master exec afterstart: ${GREEN}${CMD}${NORMAL}"
 	${CMD}
+	# restore CBSD PATH
+	export PATH="${CBSDPATH}"
 }
 
 exec_poststart()
 {
 	eval CMD=\${exec_poststart}
 	[ -z "${CMD}" -o "${CMD}" = "0" ] && return 0
+	local CBSDPATH="${PATH}"
+	# reset CBSD PATH
+	export PATH="/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin"
 	${ECHO} "${MAGENTA}${jname} exec exec_poststart: ${GREEN}${CMD}${NORMAL}"
 	jexec jname=${jname} ${CMD}
+	# restore CBSD PATH
+	export PATH="${CBSDPATH}"
 }
 
 exec_cbsdjail_first_boot()
 {
 	if [ -f ${path}/etc/rc.cbsdjail_first_boot ]; then
+		local CBSDPATH="${PATH}"
+		# reset CBSD PATH
+		export PATH="/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin"
 		jexec jname=${jname} /bin/sh /etc/rc.cbsdjail_first_boot
+		# restore CBSD PATH
+		export PATH="${CBSDPATH}"
 		/bin/rm -f ${path}/etc/rc.cbsdjail_first_boot
 	fi
 }
@@ -74,16 +89,26 @@ exec_master_prestart()
 {
 	eval CMD=\${exec_master_prestart}
 	[ -z "${CMD}" -o "${CMD}" = "0" ] && return 0
+	local CBSDPATH="${PATH}"
+	# reset CBSD PATH
+	export PATH="/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin"
 	${ECHO} "${MAGENTA}${jname} master exec prestart: ${GREEN}${CMD}${NORMAL}"
 	${CMD}
+	# restore CBSD PATH
+	export PATH="${CBSDPATH}"
 }
 
 exec_prestart()
 {
 	eval CMD=\${exec_prestart}
 	[ -z "${CMD}" -o "${CMD}" = "0" ] && return 0
+	local CBSDPATH="${PATH}"
+	# reset CBSD PATH
+	export PATH="/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin"
 	${ECHO} "${MAGENTA}${jname} exec exec_prestart: ${GREEN}${CMD}${NORMAL}"
 	jexec jname=${jname} ${CMD}
+	# restore CBSD PATH
+	export PATH="${CBSDPATH}"
 }
 
 # return in $FWNUM first free ipfw num

--- a/tools.subr
+++ b/tools.subr
@@ -7,6 +7,7 @@ _CBSD_TOOLS_SUBR=1
 #return 1 errcode for ipv4
 #return 2 errcode for ipv6
 # fill VHID args when CARP-specific records
+# export IWM global variables
 iptype() {
 	local prefix p1 p2 ip
 	[ -z "${1}" ] && return 0

--- a/tools/bconstruct-tui
+++ b/tools/bconstruct-tui
@@ -1,5 +1,5 @@
 #!/usr/local/bin/cbsd
-#v10.1.0
+#v11.1.3
 MYARG=""
 MYOPTARG="mode"
 MYDESC="Ncurses based Bhyve guest creation wizard"
@@ -90,6 +90,15 @@ dialog_menu_main()
 
 	if [ "${from_jail}" = "1" -a "${bhyve_profile}" != "FreeBSD-bsdinstall-jail" ]; then
 		menu_list="${menu_list} '${item_let} jprofile'  '$(curval jprofile)'    'Select jail profile for jcreate'"
+	fi
+
+	local vm_package_num=$( cbsdsql local SELECT COUNT\(name\) FROM vmpackages )
+
+	if ! is_number ${vm_package_num}; then
+		if [ ${vm_package_num} -gt 0 ]; then
+			menu_list="${menu_list} '${item_let} vm_package'	'$(curval vm_package)'		'Package group name'"
+			inc_menu_index item_let
+		fi
 	fi
 
 	menu_list="${menu_list} '${item_let} jname'		'$(curval jname)'		'A short jail name'"
@@ -217,6 +226,8 @@ f_dialog_backtitle "${ipgm:+bsdconfig }$pgm"
 f_mustberoot_init
 
 vm_iso_path="${register_iso_as}"
+
+apply_vm_package
 
 while [ 1 ]; do
 	pkgnum=0

--- a/tools/bhyvenic
+++ b/tools/bhyvenic
@@ -23,10 +23,10 @@ init $*
 #[ "${shownode}" = "1" ] && display="nodename,${display}"
 
 #remove commas for loop action on header
-mydisplay=$(echo ${display} |tr ',' '  ')
+mydisplay=$(echo ${display} |/usr/bin/tr ',' '  ')
 
 # upper for header
-myheader=$(echo ${mydisplay} |tr '[:lower:]' '[:upper:]')
+myheader=$(echo ${mydisplay} |/usr/bin/tr '[:lower:]' '[:upper:]')
 
 show_header()
 {

--- a/tools/freejname
+++ b/tools/freejname
@@ -1,5 +1,5 @@
 #!/usr/local/bin/cbsd
-#v11.0.0
+#v11.1.3
 MYARG=""
 MYOPTARG="default_jailname"
 MYDESC="Suggest first available jname"
@@ -16,11 +16,30 @@ init $*
 freejname()
 {
 	local _num _newjname
+	local _nodes _i _test _exist
+
+	# also find by remote nodes databases, but local is first
+	_nodes=$( cbsdsql nodes SELECT nodename FROM nodelist 2>/dev/null )
+	_nodes="local ${_nodes}"
 
 	for _num in $( /usr/bin/jot 10000 ); do
 		_newjname="${default_jailname}${_num}"
-		jstatus jname=${_newjname} > /dev/null 2>/dev/null
-		[ $? -eq 0 ] && break
+		_exist=0
+
+		for _i in ${_nodes}; do
+			_test=
+			_test=$( cbsdsql ${_i} SELECT jname FROM jails WHERE jname=\"${_newjname}\" )
+			[ -n "${_test}" ] && _exist=1 && break
+		done
+
+		case "${_exist}" in
+			0)
+				break
+				;;
+			1)
+				continue
+				;;
+		esac
 	done
 
 	echo ${_newjname}

--- a/tools/getinfo
+++ b/tools/getinfo
@@ -1,5 +1,5 @@
-#!/bin/sh
-#v9.0.0
+#!/usr/local/bin/cbsd
+#v11.1.3
 globalconf="${workdir}/cbsd.conf";
 GENUMARG=1
 # getinfo param param ...
@@ -26,7 +26,7 @@ if [ -f "${workdir}/ver" ]; then
 fi
 
 QUIET=0
-if [ "${1}" = "-q" ]; then
+if [ "${1}" = "-q" -o "${1}" = "mode=quiet" ]; then
     QUIET=1
     shift
 fi
@@ -93,6 +93,9 @@ echo "${OID}: ${disks}"
 ;;
 "netif")
 echo "${OID}: ${netif}"
+;;
+"nodeip")
+echo "${nodeip}"
 ;;
 *)
 echo "error: No such ${OID}"

--- a/tools/media
+++ b/tools/media
@@ -15,6 +15,7 @@ mode=delete|remove - unregister and delete media file (req: name, path)\n\
 mode=deleteall|removeall - unregister and delete all ISO files\n\
 mode=get - print 'name' or 'path' for 'path=' or 'name='\n\
 mode=update - update type or jname by 'path=' and 'name='\n\
+mode=dump - dump SQL records by line\n\
 type=iso or hdd\n\
 display= list by comma for column. Default: name,path,type,jname,size\n"
 
@@ -412,6 +413,25 @@ case "${mode}" in
 	update)
 		[ -n "${type}" ] && update_type
 		[ -n "${jname}" ] && update_jname
+		;;
+	dump)
+		# export media data to ascii file
+		[ ! -r ${dbdir}/storage_media.sqlite ] && err 1 "${MAGENTA}Not readable: ${GREEN}${dbdir}/storage_media.sqlite${NORMAL}"
+		if [ -n "${jname}" ]; then
+			_sql="SELECT name,path,type,size,jname FROM media WHERE jname=\"${jname}\""
+		else
+			_sql="SELECT name,path,type,size,jname FROM media"
+		fi
+		osqldelimer=${sqldelimer}
+		sqldelimer="|"
+		OIFS=${IFS}
+		IFS="|"
+		cbsdsql storage_media ${_sql} | while read name path type size jname; do
+			_mysql="INSERT INTO media ( name, path, type, size, jname ) VALUES ( \"${name}\", \"${path}\", \"${type}\", \"${size}\", \"${jname}\" );"
+			echo "${_mysql}"
+		done
+		IFS=${OIFS}
+		sqldelimer=${osqldelimer}
 		;;
 	*)
 

--- a/tools/show_profile_list
+++ b/tools/show_profile_list
@@ -2,7 +2,7 @@
 #v11.0.0
 MYARG="search_profile"
 MYOPTARG="display header active"
-MYDESC="Operate with bhyve disk images and databse"
+MYDESC="Operate with bhyve disk images and database"
 CBSDMODULE="sys"
 ADDHELP="search_profile= - prefix for filename, e.g: vm-${vm_os_type}, ${emulator}-freebsd- \n\
 header=0 don't print header\n\

--- a/tools/vm-packages
+++ b/tools/vm-packages
@@ -1,0 +1,93 @@
+#!/usr/local/bin/cbsd
+#v11.1.2
+MYARG=""
+MYOPTARG="display header active"
+MYDESC="Operate with vm_packages database"
+CBSDMODULE="sys"
+ADDHELP="header=0 don't print header\n\
+display= list by comma for column. Default: name,pkg_vm_cpus,pkg_vm_ram,pkg_vm_disk\n"
+
+. ${subr}
+. ${system}
+. ${strings}
+. ${tools}
+
+init $*
+
+[ -z "${display}" ] && display="name,pkg_vm_cpus,pkg_vm_ram,pkg_vm_disk"
+
+#remove commas for loop action on header
+mydisplay=$(echo ${display} |/usr/bin/tr ',' '  ')
+
+# upper for header
+myheader=$(echo ${mydisplay} |/usr/bin/tr '[:lower:]' '[:upper:]')
+
+show_header()
+{
+	local _header="${BOLD}${myheader}${NORMAL}"
+	[ ${header} -eq 1 ] && $ECHO ${_header}
+}
+
+# if $1 = "Unregister" then overwrite status to "Unregister"
+populate_output_data()
+{
+	local _i _val
+
+	_status=
+
+	printf "${NORMAL}" # for column sort
+
+	#populate values for in output string
+	for _i in ${mydisplay}; do
+
+		_val=""
+
+		eval _val="\$$_i"
+		[ -z "${_val}" ] && _val="\-"
+
+		printf "${_val} "
+	done
+
+	printf "\n"
+}
+
+
+# $1 - which file from. Eg: local
+show_jaildata_from_sql()
+{
+	local _i
+
+	#   set sqlfile for ". rcconf" including
+	if [ -n "${1}" ]; then
+		sqlfile="$1"
+	else
+		sqlfile="local"
+	fi
+
+	[ -n "${2}" ] && local jname="${2}"
+
+	_sql="SELECT name,pkg_vm_cpus,pkg_vm_ram,pkg_vm_disk FROM vmpackages"
+	cbsdsql ${sqlfile} ${_sql}| while read name pkg_vm_cpus pkg_vm_ram pkg_vm_disk; do
+		populate_output_data
+		${ECHO} ${_status}
+	done
+}
+
+
+show_local()
+{
+	local _errcode _status
+
+	show_header
+	show_jaildata_from_sql local
+}
+
+show_vhid()
+{
+	show_local
+}
+
+#### MAIN
+[ -z "${header}" ] && header=1
+sqldelimer=" "
+show_local | /usr/bin/column -t

--- a/tools/vm-packages-tui
+++ b/tools/vm-packages-tui
@@ -1,0 +1,313 @@
+#!/usr/local/bin/cbsd
+. ${subr}
+. ${strings}
+
+############################################################ FUNCTIONS
+
+# dialog_menu_main
+#
+# Display the dialog(1)-based application main menu.
+#
+dialog_menu_main()
+{
+	local _input _retval
+
+	local btitle="$DIALOG_BACKTITLE"
+
+	local title=" Packages list "
+	hline=
+
+	local prompt="${_desc}"
+	local sqldelimer=" "
+
+	local mark
+
+	local menu_list=$( cbsdsql local SELECT name,pkg_vm_cpus,pkg_vm_ram,pkg_vm_disk,timestamp FROM vmpackages | while read name pkg_vm_cpus pkg_vm_ram pkg_vm_disk timestamp; do
+		eval mark=\$packages_selected_${name}
+		if [ "${mark}" = "1" ]; then
+			mark="X"
+		else
+			mark=" "
+		fi
+		echo "'${name}'	'[${mark}] name=${name} CPU=${pkg_vm_cpus} RAM=${pkg_vm_ram} DISK=${pkg_vm_disk}'	'description'"
+	done ) || err 1 "${MAGENTA}Error while create packages map${NORMAL}"
+
+	[ -z "${menu_list}" ] && menu_list="''	'no data'	''"
+
+	local height width rows
+	eval f_dialog_menu_with_help_size height width rows \
+		\"\$title\"  \
+		\"\$btitle\" \
+		\"\$prompt\" \
+		\"\$hline\"  \
+		$menu_list
+
+	# Obtain default-item from previously stored selection
+	f_dialog_default_fetch defaultitem
+
+	local menu_choice
+	menu_choice=$( eval $DIALOG \
+		--clear                                 \
+		--title \"\$title\"                     \
+		--backtitle \"\$btitle\"                \
+		--hline \"\$hline\"                     \
+		--item-help                             \
+		--ok-label \"\$msg_ok\"                 \
+		--cancel-label \"Remove\"               \
+		--extra-button                          \
+		--extra-label \"Add\"                   \
+		--help-button				\
+		--help-label \"Exit\"			\
+		${USE_XDIALOG:+--help \"\"}             \
+		--default-item \"\$defaultitem\"        \
+		--menu \"\$prompt\"                     \
+		$height $width $rows                    \
+		$menu_list                              \
+		2>&1 >&$DIALOG_TERMINAL_PASSTHRU_FD
+	)
+
+	local retval=$?
+	f_dialog_data_sanitize menu_choice
+	f_dialog_menutag_store "$menu_choice"
+
+	# Only update default-item on success
+	[ $retval -eq $DIALOG_OK ] && f_dialog_default_store "$menu_choice"
+	return $retval
+}
+
+
+item_add()
+{
+	local _par VAL
+	local btitle="$DIALOG_BACKTITLE"
+	local prompt="Use menu for select and edit limit"
+	local hline=
+
+	local title=" Add packages "
+	local _mydesc
+
+	local name pkg_vm_cpus pkg_vm_ram pkg_vm_disk
+
+	while [ 1 ]; do
+
+		# default
+		[ -z "${name}" ] && name="small1"
+		[ -z "${pkg_vm_cpus}" ] && pkg_vm_cpus="1"
+		[ -z "${pkg_vm_ram}" ] && pkg_vm_ram="1g"
+		[ -z "${pkg_vm_disk}" ] && pkg_vm_disk="10g"
+
+		local menu_list=
+
+		menu_list="
+			'name'		'${name}'		'name of the package, one-word, e.g: small1'
+			'pkg_vm_cpus'	'${pkg_vm_cpus}'	'Maximum amount of Vcore/CPU, e.g: 1'
+			'pkg_vm_ram'	'${pkg_vm_ram}'		'Maximum amount of RAM, e.g: 1m'
+			'pkg_vm_disk'	'${pkg_vm_disk}'	'Maximum amount of first disk (bootable), e.g: 10g'
+		"
+
+		menu_list="${menu_list} 'COMMIT'	'Save changes and quit'	'Save!'"
+
+		local height width rows
+		eval f_dialog_menu_with_help_size height width rows \
+			\"\$title\"  \
+			\"\$btitle\" \
+			\"\$prompt\" \
+			\"\$hline\"  \
+			$menu_list
+
+		# Obtain default-item from previously stored selection
+		f_dialog_default_fetch defaultitem
+
+		mtag=$( eval $DIALOG \
+			--clear                                 \
+			--title \"\$title\"                     \
+			--backtitle \"\$btitle\"                \
+			--hline \"\$hline\"                     \
+			--item-help                             \
+			--ok-label \"\$msg_ok\"                 \
+			--cancel-label \"Exit\"                 \
+			${USE_XDIALOG:+--help \"\"}             \
+			--default-item \"\$defaultitem\"        \
+			--menu \"\$prompt\"                     \
+			$height $width $rows                    \
+			$menu_list                              \
+			2>&1 >&$DIALOG_TERMINAL_PASSTHRU_FD
+		)
+
+		local retval=$?
+		f_dialog_data_sanitize mtag
+		f_dialog_menutag_store "$mtag"
+
+		# Only update default-item on success
+		[ $retval -eq $DIALOG_OK ] && f_dialog_default_store "$mtag"
+
+		case ${retval} in
+			${DIALOG_OK})
+				if [ "${mtag}" = "COMMIT" ]; then
+					[ -z "${name}" ] && f_dialog_msgbox "name must be filled" && continue
+					[ -z "${pkg_vm_cpus}" ] && f_dialog_msgbox "pkg_vm_cpus must be filled" && continue
+					[ -z "${pkg_vm_ram}" ] && f_dialog_msgbox "pkg_vm_ram must be filled" && continue
+					[ -z "${pkg_vm_disk}" ] && f_dialog_msgbox "pkg_vm_disk must be filled" && continue
+					cbsdsql local "INSERT INTO vmpackages ( name,pkg_vm_cpus,pkg_vm_ram,pkg_vm_disk ) VALUES ( \"${name}\",\"${pkg_vm_cpus}\",\"${pkg_vm_ram}\",\"${pkg_vm_disk}\" )"
+					return ${retval}
+				else
+					get_construct_vm_packages_${mtag}
+					continue
+				fi
+				;;
+			${DIALOG_CANCEL})
+				return $retval
+				;;
+			*)
+				return ${retval}
+				;;
+		esac
+	done
+
+}
+
+get_construct_vm_packages_name()
+{
+	title=" name "
+	prompt=" Enter name "
+	defaultitem="${name}"
+	cbsd_inputbox_simple && name="${mtag}"
+}
+
+get_construct_vm_packages_pkg_vm_cpus()
+{
+	title=" Vcore/CPU "
+	prompt=" Enter Vcore, e.g: 1 "
+	defaultitem="${pkg_vm_cpus}"
+	cbsd_inputbox_simple && pkg_vm_cpus="${mtag}"
+}
+
+get_construct_vm_packages_pkg_vm_ram()
+{
+	title=" ram "
+	prompt=" Enter RAM, e.g: 1g "
+	defaultitem="${pkg_vm_ram}"
+	cbsd_inputbox_simple && pkg_vm_ram="${mtag}"
+}
+
+get_construct_vm_packages_pkg_vm_disk()
+{
+	title=" disk "
+	prompt=" Enter 1st disk size, e.g: 10g "
+	defaultitem="${pkg_vm_disk}"
+	cbsd_inputbox_simple && pkg_vm_disk="${mtag}"
+}
+
+
+item_remove()
+{
+	[ -z "${mark_list}" ] && return 0
+
+	local _i
+
+	for _i in ${mark_list}; do
+		cbsdsql local "DELETE FROM vmpackages WHERE name='${_i}'"
+	done
+
+	unset mark_list
+	return 0
+}
+
+
+############################################################ MAIN
+export NOCOLOR=1
+
+MYARG=""
+MYOPTARG=""
+MYDESC="Edit properties for vitual image of VM"
+CBSDMODULE="bhyve"
+
+globalconf="${workdir}/cbsd.conf";
+
+set -e
+. ${globalconf}
+set +e
+
+. ${subr}
+. ${strings}
+. ${tools}
+init $*
+
+. ${settingstui}
+. ${dialog}
+. ${workdir}/carp.subr
+
+#
+# Process command-line arguments
+#
+while getopts h$GETOPTS_STDARGS flag; do
+	case "$flag" in
+	h|\?) f_usage $BSDCFG_LIBE/$APP_DIR/USAGE "PROGRAM_NAME" "$pgm" ;;
+	esac
+done
+shift $(( $OPTIND - 1 ))
+
+#
+# Initialize
+#
+f_dialog_title " VHIDs "
+f_dialog_backtitle "${ipgm:+bsdconfig }$pgm"
+f_mustberoot_init
+
+
+mark_list=
+
+#
+# Loop over the main menu until we've accomplished what we came here to do
+#
+while :; do
+	dialog_menu_main
+	ret=$?
+
+	case $ret in
+		${DIALOG_OK})
+			f_dialog_menutag_fetch mtag
+			case "$mtag" in
+				?" $msg_exit")
+					break
+					;;
+				"-")
+					continue
+					;;
+				*)
+					vhid=${mtag%% *}
+					# val=${mtag##* }
+					eval mark=\$packages_selected_${vhid}
+					if [ "${mark}" = "1" ];then
+						eval "packages_selected_${vhid}=\"0\""
+						old_mark_list="${mark_list}"
+						mark_list=
+						for i in ${old_mark_list}; do
+							[ "${i}" != "${vhid}" ] && mark_list="${mark_list} ${i}"
+						done
+					else
+						eval "packages_selected_${vhid}=\"1\""
+						mark_list="${mark_list} ${vhid}"
+					fi
+					;;
+			esac
+			;;
+		${DIALOG_CANCEL})
+			item_remove
+			continue
+			;;
+		${DIALOG_EXTRA})
+			item_add
+			continue
+			;;
+		*)
+			f_die
+			;;
+	esac
+done
+
+return $SUCCESS
+
+################################################################################
+# END
+################################################################################

--- a/tools/zfs-migrator
+++ b/tools/zfs-migrator
@@ -1,0 +1,971 @@
+#!/usr/local/bin/cbsd
+MYARG=""
+MYOPTARG="jname node full inter incr aincr incrcnt aremove"
+MYDESC="ZFS migrator for CBSD"
+CBSDMODULE="sys"
+EXTHELP="wf_zfs_migrator.html"
+ADDHELP="full=1,0 - full migration cycle - j2prepare, sync, jswmode. ( 1 -default )\n\
+inter=0 to prevent any questions and to accept answers by default\n\
+incr=0,1 - when 1, perform an incremental migration (default is 0)\n\
+aincr=0,1 - when 1, perform automatic incremental mode (default is 0)\n\
+aremove=0,1,3 - if aremove=0, don't remove source instance after migration without asking\n\
+  if aremove=1, auto remove source instance after migration without asking\n\
+  if aremove=3 (by default), and inter not 0, show yesno prompt for interactive choice\n"
+
+. ${subr}
+. ${system}
+. ${strings}
+. ${tools}
+
+clear_stfile()
+{
+	if [ "x${STFILE}" != "x" ]; then
+		if [ -f ${STFILE} ]; then
+			echo "* Clearing state file: ${DC_NAME}:${STFILE}"
+			${RM} ${STFILE} > /dev/null 2>&1
+		fi
+	fi
+}
+
+inst_stop () {
+	${ECHO} "${MAGENTA}**** ${GREEN}Runtime impact and pre-migration changes to ${emulator} instance${NORMAL}"
+	${ECHO} "${MAGENTA}**** ${GREEN}${jname} (${host_hostname})${NORMAL}"
+	if [ "${jail_status}" = "running" ]; then
+		${ECHO} "${MAGENTA}* ${GREEN}Instance ${fqdn} is running; shutting it down, please wait${NORMAL}"
+		case "${emulator}" in
+			jail)
+				jstop jname=${jname}
+				;;
+			bhyve)
+				bstop jname=${jname}
+				;;
+		esac
+		INST_STATE="stopped"
+		${ECHO} "${GREEN}Done, new state is ${INST_STATE}"
+	else
+		${ECHO} "${MAGENTA}* ${GREEN}Instance ${jname} is already shutdown.  Proceeding.${NORMAL}"
+	fi
+}
+
+
+# full migration cycle
+full=1
+# interactive
+inter=1
+ALWAYS_YES=1
+
+# Incremental by default is 0
+incr=0
+
+# incrCnt not implemented yet
+#incrCnt
+
+# Automatic Incremental by default is 0
+aincr=0
+
+# Automatic remove by default: ask user's
+aremove=3
+
+init $*
+
+if [ ${inter} -eq 1 ]; then
+	[ -z "${jname}" ] && err 1 "${MAGENTA}Empty jname=${NORMAL}"
+	[ -z "${node}" ] && err 1 "${MAGENTA}Empty node=${NORMAL}"
+fi
+
+# ZFS only
+case ${zfsfeat} in
+	1)
+		. ${zfstool}
+		;;
+	*)
+		err 1 "${MAGENTA}zfs-migrator for ZFS-based system only. Current host has zfsfeat is ${GREEN}${zfsfeat}${NORMAL}"
+esac
+
+. ${workdir}/bhyve.subr
+
+#
+# set some vars:
+BASENAME='/usr/bin/basename'
+scriptName=`${BASENAME} ${0}`
+ASver="3.2.3"
+AWK='/usr/bin/awk'
+BC='/usr/bin/bc'
+CAT='/bin/cat'
+CHOWN='/usr/sbin/chown'
+CHMOD='/bin/chmod'
+CUT='/usr/bin/cut'
+CURL='/usr/local/bin/curl'
+CURL_OPTS='--connect-timeout 10 -sS -i -H accept:application/json -H content-type:application/json'
+DATE='/bin/date'
+STTIME=`${DATE} +%s`
+BEGTIME=""
+DTIME=""
+ETIME=""
+ENDTIME=""
+TDIFF=""
+DIFFT=""
+GREP='/usr/bin/grep'
+IMGADM='/usr/sbin/imgadm'
+JSON='/usr/bin/json'
+TOUCH='/usr/bin/touch'
+TAIL='/usr/bin/tail'
+KEYGEN='/usr/bin/ssh-keygen'
+LS='/bin/ls'
+MV='/bin/mv'
+NDD='/usr/sbin/ndd'
+RM='/bin/rm'
+SCP='/usr/bin/scp'
+SED='/usr/bin/sed'
+SSH='/usr/bin/ssh'
+SVCADM='/usr/sbin/svcadm'
+UCONF='/usbkey_config'
+ZFS='/sbin/zfs'
+KEYPATH="/root/.ssh/migr-key-$$"
+LOGDIR="/var/tmp"
+LOGFILE=""
+STFILE=""
+AUTHFILEBK="/root/.ssh/authorized_keys.$$"
+KEYCHK=0	# if != 0, ssh key in place; if = 0, password prompts
+OPTSSH="-q"	# if KEYCHK != 0, sets opt '-q -i KEYPATH'
+MDSSZ=0
+OIFS=${IFS}
+IpAdDr=""
+cntIncr=0
+incrCnt=""
+cntPrev=""
+prevCnt=""
+
+
+case "${incr}" in
+	0)
+		migrType="Non-Incremental"
+		;;
+	1)
+		migrType="Incremental"
+		;;
+esac
+
+case "${aincr}" in
+	1)
+		incr=1
+		aincr=1
+		migrType="automatic-Incremental"
+		;;
+esac
+
+
+# If instance is over quota, how many GB will the quota be increased so the
+# transfer can succeed? Must be an integer.
+bump_size="1"
+
+DC_NAME="datacenter1"
+
+CBSD_MIGRNAME='1504213200_cbsd_migration_1504213200'
+IMGCHK=0		# 0:  value of DS origin = '-'; we're doing a standard dataset transfer
+			# 1:  value of DS origin = 'ZROOT/:IMGJNAME@final; test for img on dest CN,
+			#     if !exist, try to import, if import fail, zfs send img followed
+			#     by incr roll up of the instance datasets
+
+IMGSND=3		# 0:  origin DS already exists on dest, no need for import
+			# 1:  unset and irrelevant
+			# 2:  origin DS ! exists on dest, try to import
+			# 3:  origin DS relation to instance lost between src and dest, don't try to import
+
+dsCNT=1
+DSORIG=0
+
+if [ ${incr} -gt 0 -a "x${incrCnt}" != "x" ]; then
+	cntIncr=${incrCnt}
+	cntPrev=$(( incrCnt - 1 ))
+fi
+
+# Collect our initial information
+${ECHO} "\n           ${MAGENTA}-: Welcome to the CBSD ZFS Migrator :-${NORMAL}"
+
+if [ -z "${jname}" ]; then
+	while [ true ]; do
+
+		read -p "Name of Instance to Move ( ? - to list, 0 - cancel ): " jname
+
+		[ "${jname}" = "0" ] && exit 0
+
+		if [ "${jname}" = "?" ]; then
+			echo -n "jails: " && /usr/local/bin/cbsd jorder
+			echo -n "bhyve: " && /usr/local/bin/cbsd border
+			continue
+		fi
+
+		vm_status=$( /usr/local/bin/cbsd jstatus jname=${jname} )
+
+		ret=$?
+		[ ${ret} -eq 1 ] && break
+		${ECHO} "${MAGENTA}No such environment here: ${GREEN}${jname}${NORMAL}"
+	done
+fi
+
+jstatus jname=${jname} > /dev/null 2>/dev/null
+[ $? -eq 0 ] && err 1 "${MAGENTA}No such jail: ${GREEN}${jname}${NORMAL}"
+
+if [ -z "${node}" ]; then
+	while [ true ]; do
+		read -p "Destination Nodename ( ? - to list, 0 - cancel ): " node
+		[ "${node}" = "0" ] && exit 0
+
+		if [ "${node}" = "?" ]; then
+			echo -n "nodes: " && cbsd node mode=list display=nodename header=0 |xargs
+			continue
+		fi
+
+		test_for_node=$( sqlite3 ~cbsd/var/db/nodes.sqlite "SELECT nodename FROM nodelist WHERE nodename=\"${node}\"" )
+		[ "${test_for_node}" = "${node}" ] && break
+		${ECHO} "${MAGENTA}No such node here: ${GREEN}${node}${NORMAL}"
+	done
+	echo
+fi
+
+if [ ${incr} -gt 0 ]; then
+	if [ -d ${LOGDIR} ]; then
+		LOGFILE="${LOGDIR}/migrator-${jname}-${node}-${STTIME}.log"
+		STFILE="${LOGDIR}/migrator-${jname}-${node}-${STTIME}.st"
+		${TOUCH} ${LOGFILE} > /dev/null 2>&1
+		if [ $? -eq 0 ]; then
+			${TOUCH} ${STFILE}
+			exec 2>&1 |tee -a ${LOGFILE}
+			exec 1>&1 |tee -a ${LOGFILE}
+			if [ -f ${STFILE} ]; then
+				SFCHK=0
+				${ECHO} "${MAGENTA}* ${GREEN}Setting state file for removal by CBSD...${NORMAL}"
+				${ECHO} "${GREEN}    + chown cbsd:cbsd ${STFILE}${NORMAL}"
+				${CHOWN} cbsd:cbsd ${STFILE}
+				if [ $? -ne 0 ]; then
+					${ECHO} "${GREEN}      !! Root privileges required to remove state file: ${STFILE}${NORMAL}"
+					SFCHK=$(( SFCHK + 1 ))
+				else
+					${ECHO} "${GREEN}    + chmod 664 ${STFILE}${NORMAL}"
+					${CHMOD} 664 ${STFILE}
+					if [ $? -ne 0 ]; then
+						${ECHO} "${GREEN}      !! Root privileges required to remove state file: ${STFILE}${NORMAL}"
+						SFCHK=$(( SFCHK + 1 ))
+					fi
+				fi
+				if [ ${SFCHK} -eq 0 ]; then
+					${ECHO} "${GREEN}  - State file modified.${NORMAL}"
+				else
+					${ECHO} "${GREEN}  - State file could not be modified!${NORMAL}"
+				fi
+			else
+				err 1 "${MAGENTA}State file does not exist: ${GREEN}${STFILE}${NORMAL}"
+			fi
+		else
+			err 1 "${MAGENTA}Could not write log and write files: ${GREEN}${LOGFILE},${STFILE}${NORMAL}"
+		fi
+	fi
+fi
+
+${ECHO} "${MAGENTA}* ${GREEN}Gathering instance and nodes data....${NORMAL}"
+${ECHO} "${GREEN}    + retrieving instance date...${NORMAL}"
+
+. ${jrcconf}
+
+myjid=$( cbsdsql local SELECT jid FROM jails WHERE jname=\"${jname}\" 2>/dev/null )
+
+case ${myjid} in
+	0)
+		jail_status="stopped"
+		;;
+	*)
+		jail_status="running"
+		;;
+esac
+
+# todo: check for IP addrs reserved
+IP_ARR="${ip4_addr}"
+
+${ECHO} "${GREEN}    + retrieving node hostname, CBSD version...${NORMAL}"
+my_nodename=$( /bin/cat ~cbsd/nodename )
+
+remote_node_ip=$( cbsd getinfo mode=quiet nodeip )
+remote_node_name="${node}"
+remote_node_rip=$( sqlite3 ~cbsd/var/db/nodes.sqlite "SELECT ip FROM nodelist WHERE nodename=\"${node}\"" 2>/dev/null )
+
+[ -z "${remote_node_rip}" ] && err 1 "${MAGENTA}Could not identify IP address for node: ${GREEN}${node}${NORMAL}"
+
+source_vm_name="${jname}"
+dest_vm_name="${jname}"
+
+# todo: check for jname on dst is not reserverved
+# todo: alternative jname on dst?
+
+${ECHO} "${GREEN}    + checking for datasets...${NORMAL}"
+
+if [ -r /tmp/.vmmigrator.$$ ]; then
+	${RM} -f /tmp/.vmmigrator.$$
+fi
+
+LOCAL_ZROOT=$( ${ZFS} get -Ho value name ${jaildatadir} 2>/dev/null )
+[ -z "${LOCAL_ZROOT}" ] && err 1 "${MAGENTA}Unable to determine local zroot${NORMAL}"
+
+# how to obtain remote jaildatadir?
+REMOTE_ZROOT=$( ${SSH} -q ${remote_node_rip} ${ZFS} get -Ho value name ${jaildatadir} 2>/dev/null | awk '{printf $1 }' )
+[ -z "${REMOTE_ZROOT}" ] && err 1 "${MAGENTA}Unable to determine remote zroot${NORMAL}"
+
+case "${emulator}" in
+	jail)
+		${ZFS} list -Hpro name,usedbydataset -t filesystem,volume ${LOCAL_ZROOT} | ${GREP} ${LOCAL_ZROOT}/${jname} 2>/dev/null >> /tmp/.vmmigrator.$$
+		;;
+	bhyve)
+		${ZFS} list -Hpro name,usedbydataset -t filesystem,volume ${LOCAL_ZROOT} | ${GREP} "${LOCAL_ZROOT}/bcbsd-${jname}-dsk[0-9].vhd" 2>/dev/null >> /tmp/.vmmigrator.$$
+		;;
+esac
+
+if [ -s /tmp/.vmmigrator.$$ ]; then
+	MDSSZ=`${AWK} 'BEGIN {tot=0}; {tot+=$2}; END {printf tot}' /tmp/.vmmigrator.$$`
+fi
+
+rise="Bytes"
+SZMDS=0
+if [ 0${MDSSZ} -lt 1024 ]; then
+	SZMDS=${MDSSZ}
+elif [ 0${MDSSZ} -lt 1048576 ]; then
+	SZMDS=`echo "scale=2; ${MDSSZ}/1024" | ${BC}`
+	rise="KBytes"
+elif [ 0${MDSSZ} -lt 1073741824 ]; then
+	SZMDS=`echo "scale=2; ${MDSSZ}/1048576" | ${BC}`
+	rise="MBytes"
+elif [ 0${MDSSZ} -lt 1099511627776 ]; then
+	SZMDS=`echo "scale=2; ${MDSSZ}/1073741824" | ${BC}`
+	rise="GBytes"
+elif [ 0${MDSSZ} -lt 1125899906842624 ]; then
+	SZMDS=`echo "scale=2; ${MDSSZ}/1099511627776" | ${BC}`
+	rise="TBytes"
+fi
+
+miti="seconds"
+mav=`echo "scale=2; ((${MDSSZ}/1048576)/20)+120" | ${BC}`
+if [ 0${MDSSZ} -gt 1048576 ]; then
+	if [ 0`echo "${mav}" | ${CUT} -d\. -f1` -gt 3600 ]; then
+		mav=`echo "scale=2; ${mav}/3600" | ${BC}`
+		miti="hours"
+	elif [ 0`echo "${mav}" | ${CUT} -d\. -f1` -gt 60 ]; then
+		mav=`echo "scale=2; ${mav}/60" | ${BC}`
+		miti="minutes"
+	fi
+fi
+
+# node key
+if [ ${KEYCHK} -ne 0 ]; then
+	OPTSSH="-q -i ${KEYPATH}"
+fi
+
+# todo: make retrinv and obtain information from SQLite directory ?
+d_cbsd_ver=$( ${SSH} -q ${remote_node_rip} /usr/local/bin/cbsd -c version 2>/dev/null |awk '{printf $1 }' )
+s_cbsd_ver=$( version )
+
+${ECHO} "${GREEN}  - Data gathering complete!${NORMAL}"
+srcpad=" "
+destpad=" "
+
+cat <<XxX1387784305xXx
+
+We will be migrating:
+     INSTANCE:
+               jname:  ${jname}
+                fqdn:  ${host_hostname}
+          IP Addr(s):  ${ip4_addr}
+          datacenter:  ${DC_NAME}
+      instance state:  ${jail_status}
+                type:  ${emulator}
+               owner:  root
+           create at:  -
+          base image:  -
+  total dataset size:  ${SZMDS} ${rise} across ${dsCNT} datasets
+        migration id:  $$
+ est. migration time:  ${mav} ${miti} (@ ~20 MB / second (~1.17 GB / minute); +2 minutes extra)
+      migration type:  ${migrType}
+XxX1387784305xXx
+if [ ${incr} -gt 0 ]; then
+	cat <<XxX1394397626xXx
+  migration log file:  ${DC_NAME}:${LOGFILE}
+migration state file:  ${DC_NAME}:${STFILE}
+XxX1394397626xXx
+fi
+
+cat <<XxX1394397713xXx
+
+                    Source                                        Destination
+----------------------------------------------  ----------------------------------------------
+XxX1394397713xXx
+printf "Host:     %-36s  Host:     %-36s\n" ${my_nodename} ${remote_node_name}
+printf "JNAME:    %-36s  JNAME:    %-36s\n" ${source_vm_name} ${dest_vm_name}
+printf "SDC Ver:  %-36s  SDC Ver:  %-36s\n" ${s_cbsd_ver} ${d_cbsd_ver}
+printf "IP Addr:  %-36s  IP Addr:  %-36s\n" ${remote_node_ip} ${remote_node_rip}
+printf "Zfs:      %-36s  Zfs:      %-36s\n" ${LOCAL_ZROOT} ${REMOTE_ZROOT}
+
+echo
+
+if getyesno "Are you ready to proceed? "; then
+	echo
+else
+	${ECHO} "${MAGENTA}Exiting.${NORMAL}"
+	clear_stfile
+	exit 1
+fi
+
+BEGTIME=`${DATE}`
+STTIME=`${DATE} +%s`
+
+${ECHO} "${MAGENTA}* ${GREEN}Checking for origin instance dataset...${NORMAL}"
+
+if [ "${emulator}" = "bhyve" ]; then
+	DSORIG=`${ZFS} get -Ho value origin ${REMOTE_ZROOT}/bcbsd-${jname}-dsk1.vhd`
+else
+	DSORIG=`${ZFS} get -Ho value origin ${REMOTE_ZROOT}/${jname}`
+fi
+
+# check if origin dataset exists and is ${REMOTE_ZROOT}/...@final, ignore otherwise
+if [ "x${DSORIG}" = "x${REMOTE_ZROOT}/${jname}@final" ]; then
+	IMGCHK=1
+	echo "    + origin dataset is ${DSORIG}"
+	DSORIG=`echo "${DSORIG}" | ${SED} -e 's;^${LOCAL_ZROOT}/;;'`
+#	DSOBJ=(`echo "${DSORIG}" | ${SED} -e 's;@; ;'`)
+	DSOBJ=$( echo "${DSORIG}" | ${SED} -e 's;@; ;' )
+	echo "DSOBJ stop: [${DSOBJ}]"
+	exit 0
+	# DSOBJ:
+	#    0:  image jname derived from dataset name (${LOCAL_ZROOT}/IMG_JNAME@something)
+	#    1:  snapshot name (part that trails @)
+else
+	${ECHO} "${GREEN}    + origin dataset null or non-standard (${DSORIG})${NORMAL}"
+fi
+
+if [ ${IMGCHK} -ne 0 ]; then
+	${SSH} -q ${remote_node_rip} ${ZFS} list -Ho name ${REMOTE_ZROOT}/${DSORIG} >/dev/null 2>&1
+	if [ $? -ne 0 ]; then
+		# bhyve?
+		${SSH} -q ${remote_node_rip} ${ZFS} list -Ho name ${REMOTE_ZROOT}/${jname} >/dev/null 2>&1
+		if [ $? -ne 0 ]; then
+			IMGSND=2	# origin DS and base image of it don't exist, will try import
+			${ECHO} "${GREEN}      > origin DS doesn't exist on ${remote_node_name}, will need to try import${NORMAL}"
+			${ECHO} "${GREEN}        of origin DS (${DSORIG})${NORMAL}"
+		else
+			IMGSND=3	# origin DS base exists, but not snap the instance was
+					#   create from, since we cannot just send the snapshot
+					#   ignoring and treating the origin as lost
+			${ECHO} "${GREEN}      > origin DS base exists on ${remote_node_name}, but not the child dataset${NORMAL}"
+			${ECHO} "${GREEN}        from which our instance was created; ignoring; parent DS relation is lost.${NORMAL}"
+		fi
+	else
+		IMGSND=0	# don't need to send over the origin DS
+		${ECHO} "${GREEN}      > origin DS exists on ${remote_node_name}, no need to import it${NORMAL}"
+	fi
+else
+	IMGSND=3
+	${ECHO} "${GREEN}      > instance source origin does not reference ${jname}@final, relation to${NORMAL}"
+	${ECHO} "${GREEN}        dest. origin will be lost in the course of migrating the instance.${NORMAL}"
+fi
+
+
+if ${SSH} -q ${remote_node_rip} "${ZFS} list ${REMOTE_ZROOT}/${jname}@vmsnap-${CBSD_MIGRNAME}" > /dev/null 2>&1; then
+	${ECHO} "${MAGENTA}ERROR: Snapshot already exists on the ${remote_node_name}!  This is not${NORMAL}"
+	${ECHO} "${MAGENTA}       your first time here.  Clean it up first please.${NORMAL}"
+	${ECHO} "${MAGENTA}  To delete the snapshots on ${remote_node_name}:${NORMAL}"
+	if [ "${emulator}" = "bhyve" ]; then
+		${ECHO} "${MAGENTA}    *${GREEN}${SSH} ${remote_node_rip} \"${ZFS} destroy -r ${REMOTE_ZROOT}/bcbsd-${jname}-dsk0.vhd\"${NORMAL}"
+		${ECHO} "${MAGENTA}    *${GREEN}${SSH} ${remote_node_rip} \"${ZFS} destroy -r ${REMOTE_ZROOT}/bcbsd-${jname}-dsk1.vhd\"${NORMAL}"
+	fi
+
+	${ECHO} "${MAGENTA}    *${GREEN}${SSH} ${remote_node_rip} \"${ZFS} destroy -r ${REMOTE_ZROOT}/${jname}\"${NORMAL}"
+	clear_stfile
+	exit 1
+fi
+
+if [ ${full} -eq 1 ]; then
+	printf "${MAGENTA}*${NORMAL} "
+	jaillock="${jailsysdir}/${jname}/locked"
+	[ -r "${jaillock}" ] && ${RM} ${jaillock}
+
+	case "${emulator}" in
+		jail)
+			j2prepare node=${node} jname=${jname} mkdatadir=0
+			;;
+		bhyve)
+			# export media data
+			media mode=dump jname=${jname} > ${jailsysdir}/${jname}/media.sql
+			j2prepare node=${node} jname=${jname} mkdatadir=1
+			;;
+	esac
+
+	echo
+fi
+
+if [ ${IMGSND} -eq 2 ]; then
+	${ECHO} "${MAGENTA}* ${GREEN}Attempting import of image (${jname}) to ${remote_node_name}${NORMAL}"
+	if [ $? -ne 0 ]; then
+		echo "  - Image import failed, failing back to zfs transfer of image!"
+		echo "    + Attempting zfs transfer of image to ${remote_node_name}"
+		${SSH} -q -t ${remote_node_ip} "${ZFS} send -p ${LOCAL_ZROOT}/${DSORIG} | ${SSH} ${OPTSSH} ${remote_node_rip} ${ZFS} recv -e ${REMOTE_ZROOT}" 2>/dev/null
+		if [ $? -eq 0 ]; then
+			echo "      > zfs transfer of image to ${remote_node_name} succeeded"
+			${SSH} -q -t ${remote_node_ip} "${LS} ${MANIPATH}/zones-${DSOBJ[0]}.json > /dev/null 2>&1"
+			if [ $? -eq 0 ]; then
+				echo "    + Attempting transfer of image manifest to ${remote_node_name}"
+				${SSH} -q -t ${remote_node_ip} "${SCP} ${OPTSSH} ${MANIPATH}/zones-${DSOBJ[0]}.json root@${remote_node_rip}:${MANIPATH}/. " 2>/dev/null
+				${SSH} -q -t ${remote_node_rip} "${LS} ${MANIPATH}/zones-${DSOBJ[0]}.json > /dev/null 2>&1"
+				if [ $? -eq 0 ]; then
+					echo "      > transfer of image manifest to ${remote_node_name} succeeded"
+					echo "  - Image imported successfully!"
+					IMGSND=0
+				else
+					printf "      > transfer of image manifest to ${remote_node_name} failed; will now\n        consider the origin dataset of our instance as lost!"
+					echo "  - Image import failed!"
+					IMGSND=3
+				fi
+			else
+				printf "      > cannot locate image manifest on ${remote_node_name}; will now\n        consider the origin dataset of our instance as lost!"
+				echo "  - Image import failed!"
+				IMGSND=3
+			fi
+		else
+			printf "      > zfs transfer of image to ${remote_node_name} failed; will now\n        consider the origin dataset of our instance as lost!"
+			echo "  - Image import failed!"
+			IMGSND=3
+		fi
+	else
+		echo "  - Image imported successfully!"
+		IMGSND=0
+	fi
+fi
+
+# function
+fsNotExist() {
+	local dset=$1
+	${SSH} ${OPTSSH} ${remote_node_rip} ${ZFS} list ${dset%@*} 2>/dev/null >/dev/null
+	return $?
+}
+
+# function
+transferError() {
+	echo
+	echo "      > transfer failed!"
+	printf "\n  - Clearing migration SSH key and exiting."
+	clear_stfile
+	exit 24
+}
+
+# function
+transferQuota() {
+    local dset=$1
+    shift
+    local dsetQuota=$(${SSH} -q -t ${remote_node_ip} "${ZFS} get -Hp -o value quota ${dset}" | tr -d '[[:space:]]')
+    if [ ${dsetQuota} -eq 0 ]; then
+        return;
+    fi
+
+    local dsetSpace=$(${SSH} -q -t ${remote_node_ip} "${ZFS} list -Hp -o used ${dset}" | tr -d '[[:space:]]')
+    local freeSpace=$((${dsetQuota} - ${dsetSpace}))
+    local gigabyte=$((1024 * 1024 * 1024))
+    local quota_bump_msg=""
+
+    if [ ${freeSpace} -lt ${gigabyte} ]; then
+        dsetQuota=$((${dsetQuota} + ${gigabyte} * ${bump_size}))
+        quota_bump_msg="(+${bump_size}Gb)"
+    fi
+
+    ${SSH} -q -t ${remote_node_rip} ${ZFS} set quota=${dsetQuota} ${dset} && \
+        printf " quota${quota_bump_msg}..." || transferError
+}
+
+# function()
+transferOptions() {
+	local dset=$1
+	shift
+	local fields=$(echo $@ | sed 's/ /,/g')
+
+	local opts=$(${SSH} -q -t ${remote_node_ip} "${ZFS} get -Hp -o property,value ${fields} ${dset}" | awk \
+		'{if ($2 !~ /^(none|-)/) printf $1"="$2}')
+
+	if [ ! -z ${opts} ]; then
+		printf "    + Transferring dataset options to ${dset}..."
+		for opt in ${opts};do
+		    if [ ${opt%=*} = "quota" ]; then
+		        transferQuota ${dset}
+		    else
+				${SSH} -q -t ${remote_node_rip} ${ZFS} set ${opt} ${dset} && printf " ${opt}..." || transferError
+		    fi
+		done
+		echo " done..."
+	fi
+
+}
+
+# function
+transferAll() {
+	local dset=$1
+	local origin=$(${SSH} -q -t ${remote_node_ip} "${ZFS} get origin ${dset%@*}" | ${TAIL} -n 1 | ${AWK} '{printf $3}')
+	if [ "x${origin}" != "x-" ]; then
+		fsNotExist ${origin}
+		if [ $? -ne 0 ];then
+			transferAll ${origin}
+		fi
+		fsNotExist ${dset}
+		if [ $? -ne 0 ];then
+#			${SSH} -q -t ${remote_node_ip} \
+#				"${ZFS} send -I ${origin} ${dset} | ${SSH} ${OPTSSH} ${remote_node_rip} ${ZFS} recv -d zones" \
+#				2>/dev/null && echo "done" || transferError
+			${SSH} -q -t ${remote_node_ip} \
+				"${ZFS} send -I ${origin} ${dset} | ${SSH} ${OPTSSH} ${remote_node_rip} ${ZFS} recv -e ${REMOTE_ZROOT}" \
+				2>/dev/null && echo "done" || transferError
+		fi
+	else
+#		${SSH} -q -t ${remote_node_ip} "${ZFS} send -p ${dset} | ${SSH} ${OPTSSH} ${remote_node_rip} ${ZFS} recv -d zones" \
+#			2>/dev/null && echo "done" || transferError
+		${SSH} -q -t ${remote_node_ip} "${ZFS} send -p ${dset} | ${SSH} ${OPTSSH} ${remote_node_rip} ${ZFS} recv -e ${REMOTE_ZROOT}" \
+			2>/dev/null && echo "done" || transferError
+	fi
+
+	transferOptions ${dset%@*} quota
+}
+
+# Snapshotting and transfer
+if [ ${incr} -eq 0 ]; then
+	# NO incrEMENTAL MIGRATION
+	DTIME=`${DATE} +%s`
+	inst_stop
+	# todo: remote modification
+	${ECHO} "${MAGENTA}* ${GREEN}Creating dataset snapshots on ${my_nodename}${NORMAL}"
+	for dset in `${AWK} '{printf $1}' /tmp/.vmmigrator.$$`; do
+		${ECHO} "${GREEN}    + Creating ${dset} snapshot...${NORMAL}"
+		${ZFS} snapshot ${dset}@vmsnap-${CBSD_MIGRNAME} > /dev/null
+		echo "${dset}" | ${GREP} disk >/dev/null 2>&1
+	done
+
+	echo
+
+	${ECHO} "${MAGENTA}* ${GREEN}Transferring dataset snapshots to ${remote_node_name}${NORMAL}"
+	if [ ${IMGSND} -eq 3 ]; then
+		# origin DS ! exists on DEST, send over the instance breaking any parent DS relation
+		for dset in `${AWK} '{printf $1}' /tmp/.vmmigrator.$$` ; do
+			${ECHO} "${GREEN}    + Tranferring ${dset}@vmsnap-${CBSD_MIGRNAME} ...${NORMAL}"
+			${ZFS} send -p ${dset}@vmsnap-${CBSD_MIGRNAME} | ${SSH} ${OPTSSH} ${remote_node_rip} ${ZFS} recv -e ${REMOTE_ZROOT} 2>/dev/null
+			if [ $? -ne 0 ]; then
+				${ECHO} "${MAGENTA}      > transfer failed!${NORMAL}"
+				clear_stfile
+				exit 1
+			fi
+		done
+	elif [ ${IMGSND} -eq 0 ]; then
+		# origin DS exists on DEST, perform an incremental replication stream of instance dataset
+		#   between the origin DS and the instance migration snapshot and send that to DEST
+		for dset in `${AWK} '{printf $1}' /tmp/.vmmigrator.$$` ; do
+			${ECHO} "${GREEN}    + Tranferring ${dset}@vmsnap-${CBSD_MIGRNAME} ...${NORMAL}"
+			if [ "${emulator}" = "bhyve" ]; then
+				echo "${dset}" | ${GREP} dsk0.vhd >/dev/null 2>&1
+				if [ $? -eq 0 ]; then
+					# for KVMs, send the incremental replication stream only for dsk0
+					#   since dsk0 is tied to the origin dataset, otherwise just send
+					#   over the datasets
+					${SSH} -q -t ${remote_node_ip} "${ZFS} send -RI ${LOCAL_ZROOT}/${DSORIG} ${dset}@vmsnap-${CBSD_MIGRNAME} | ${SSH} ${OPTSSH} ${remote_node_rip} ${ZFS} recv -e ${REMOTE_ZROOT}" 2>/dev/null
+					if [ $? -ne 0 ]; then
+						${ECHO} "${MAGENTA}      > transfer failed!${NORMAL}"
+						clear_stfile
+						exit 1
+					fi
+				else
+					${SSH} -q -t ${remote_node_ip} "${ZFS} send -p ${dset}@vmsnap-${CBSD_MIGRNAME} | ${SSH} ${OPTSSH} ${remote_node_rip} ${ZFS} recv -e ${REMOTE_ZROOT}" 2>/dev/null
+					if [ $? -ne 0 ]; then
+						${ECHO} "${MAGENTA}      > transfer failed!${NORMAL}"
+						clear_stfile
+						exit 1
+					fi
+				fi
+			else
+				# for jails, only the root dataset exists, send an incremental replication stream
+				transferAll ${dset}@vmsnap-${CBSD_MIGRNAME}
+			fi
+		done
+	fi
+else
+	# incrEMENTAL MIGRATION
+	USR1=0
+	trap 'USR1=1' USR1
+	BACKOFF=30
+	while [ -f ${STFILE} ]; do
+		${ECHO} "${MAGENTA}* ${GREEN}Creating dataset snapshots on ${my_nodename}${NORMAL}"
+		for dset in `${AWK} '{printf $1}' /tmp/.vmmigrator.$$`; do
+			${ECHO} "${GREEN}    + Creating ${dset} snapshot ${cntIncr}...${NORMAL}"
+			${ZFS} snapshot ${dset}@vmsnap-${CBSD_MIGRNAME}-${cntIncr} > /dev/null
+			echo "${dset}" | ${GREP} disk >/dev/null 2>&1
+		done
+
+		echo
+
+		echo "* Transferring incremental dataset snapshot ${cntIncr} to ${remote_node_name}"
+		if [ ${IMGSND} -eq 3 ]; then
+			# origin DS ! exists on DEST, send over the instance breaking any parent DS relation
+			if [ ${cntIncr} -eq 0 ]; then
+				for dset in `${AWK} '{printf $1}' /tmp/.vmmigrator.$$` ; do
+					printf "    + Tranferring ${dset}@vmsnap-${CBSD_MIGRNAME}-${cntIncr} ..."
+					${ZFS} send -p ${dset}@vmsnap-${CBSD_MIGRNAME}-${cntIncr} | ${SSH} ${OPTSSH} ${remote_node_rip} ${ZFS} recv -e ${REMOTE_ZROOT} 2>/dev/null
+					if [ $? -ne 0 ]; then
+						${ECHO} "${MAGENTA}      > transfer failed!${NORMAL}"
+						clear_stfile
+						exit 1
+					fi
+				done
+			else
+				for dset in `${AWK} '{printf $1}' /tmp/.vmmigrator.$$` ; do
+					${ECHO} "    + Tranferring ${dset}@vmsnap-${CBSD_MIGRNAME}-${cntIncr} ...${NORMAL}"
+					${ZFS} send -i ${dset}@vmsnap-${CBSD_MIGRNAME}-${cntPrev} ${dset}@vmsnap-${CBSD_MIGRNAME}-${cntIncr} | ${SSH} ${OPTSSH} ${remote_node_rip} ${ZFS} recv -F ${dset} 2>/dev/null
+					if [ $? -ne 0 ]; then
+						${ECHO} "${MAGENTA}      > transfer failed!${NORMAL}"
+						clear_stfile
+						exit 1
+					fi
+				done
+			fi
+		elif [ ${IMGSND} -eq 0 ]; then
+			# origin DS exists on DEST, perform an incremental replication stream of instance dataset
+			#   between the origin DS and the instance migration snapshot and send that to DEST
+			if [ ${cntIncr} -eq 0 ]; then
+				for dset in `${AWK} '{printf $1}' /tmp/.vmmigrator.$$` ; do
+					${ECHO} "${GREEN}    + Tranferring ${dset}@vmsnap-${CBSD_MIGRNAME}-${cntIncr} ...${NORMAL}"
+					if [ "${emulator}" = "bhyve" ]; then
+						echo "${dset}" | ${GREP} dsk0.vhd >/dev/null 2>&1
+						if [ $? -eq 0 ]; then
+							# for KVMs, send the incremental replication stream only for dsk0
+							#   since dsk0 is tied to the origin dataset, otherwise just send
+							#   over the datasets
+							${ZFS} send -RI ${LOCAL_ZROOT}/${DSORIG} ${dset}@vmsnap-${CBSD_MIGRNAME}-${cntIncr} | ${SSH} ${OPTSSH} ${remote_node_rip} ${ZFS} recv -e ${REMOTE_ZROOT} 2>/dev/null
+							if [ $? -ne 0 ]; then
+								${ECHO} "${MAGENTA}      > transfer failed!${NORMAL}"
+								clear_stfile
+								exit 1
+							fi
+						else
+							${ZFS} send -p ${dset}@vmsnap-${CBSD_MIGRNAME}-${cntIncr} | ${SSH} ${OPTSSH} ${remote_node_rip} ${ZFS} recv -e ${REMOTE_ZROOT} 2>/dev/null
+							if [ $? -ne 0 ]; then
+								${ECHO} "${MAGENTA}      > transfer failed!${NORMAL}"
+								clear_stfile
+								exit 1
+							fi
+						fi
+					else
+						# for jails, only the root dataset exists, send an incremental replication stream
+						transferAll ${dset}@vmsnap-${CBSD_MIGRNAME}-${cntIncr}
+					fi
+				done
+			else
+				for dset in `${AWK} '{printf $1}' /tmp/.vmmigrator.$$` ; do
+					${ECHO} "${GREEN}    + Tranferring ${dset}@vmsnap-${CBSD_MIGRNAME}-${cntIncr} ...${NORMAL}"
+					${ZFS} send -i ${dset}@vmsnap-${CBSD_MIGRNAME}-${cntPrev} ${dset}@vmsnap-${CBSD_MIGRNAME}-${cntIncr} | ${SSH} ${OPTSSH} ${remote_node_rip} ${ZFS} recv -F ${dset} 2>/dev/null
+					if [ $? -ne 0 ]; then
+						${ECHO} "${MAGENTA}      > transfer failed!${NORMAL}"
+						clear_stfile
+						exit 1
+					fi
+				done
+			fi
+		fi
+		cntPrev=${cntIncr}
+		cntIncr=$(( cntIncr + 1 ))
+		echo
+		if [ ${aincr} -eq 0 ]; then
+			${ECHO} "${GREEN}    + Sleeping for ${BACKOFF} seconds before next snapshot (run 'kill -USR1 $$' to force a snapshot).${NORMAL}"
+			for i in $( /usr/bin/seq 1 ${BACKOFF} ); do
+				[ -f $STFILE ] || break
+				if [ "$USR1" = 1 ]; then
+					USR1=0
+					break
+				fi
+				sleep 1
+			done
+			[ $BACKOFF -lt 480 ] && BACKOFF=$(( 2 * BACKOFF ))
+	else
+		clear_stfile
+	fi
+	done
+	DTIME=`${DATE} +%s`
+	inst_stop
+	echo
+	${ECHO} "${MAGENTA}* ${GREEN}Creating final incrmental dataset snapshot on ${my_nodename}${NORMAL}"
+	for dset in `${AWK} '{printf $1}' /tmp/.vmmigrator.$$`; do
+		${ECHO} "${GREEN}    + Creating ${dset} snapshot ${cntIncr}...${NORMAL}"
+		${ZFS} snapshot ${dset}@vmsnap-${CBSD_MIGRNAME}-${cntIncr} > /dev/null
+		echo "${dset}" | ${GREP} disk >/dev/null 2>&1
+	done
+
+	for dset in `${AWK} '{printf $1}' /tmp/.vmmigrator.$$` ; do
+		${ECHO} "${GREEN}    + Tranferring ${dset}@vmsnap-${CBSD_MIGRNAME}-${cntIncr} ...${NORMAL}"
+		${ZFS} send -i ${dset}@vmsnap-${CBSD_MIGRNAME}-${cntPrev} ${dset}@vmsnap-${CBSD_MIGRNAME}-${cntIncr} | ${SSH} ${OPTSSH} ${remote_node_rip} ${ZFS} recv -F ${dset} 2>/dev/null
+		if [ $? -ne 0 ]; then
+			${ECHO} "${MAGENTA}      > transfer failed!${NORMAL}"
+			clear_stfile
+			exit 1
+		fi
+	done
+fi
+
+${ECHO} "${MAGENTA}* ${GREEN}Deleting migration snapshots on ${remote_node_name}...${NORMAL}"
+# Also necessary remove on local, because at the end of script, user can anser 'no' on 'remove vm?' question
+for dset in `${AWK} '{printf $1}' /tmp/.vmmigrator.$$`; do
+	if [ ${incr} -eq 0 ]; then
+		${SSH} -q ${remote_node_rip} "${ZFS} destroy ${dset}@vmsnap-${CBSD_MIGRNAME}" 2>/dev/null
+		${ZFS} destroy ${dset}@vmsnap-${CBSD_MIGRNAME} 2>/dev/null
+	else
+		prevCnt=${cntIncr}
+		while [ ${prevCnt} -ge 0 ]; do
+			${SSH} -q ${remote_node_rip} "${ZFS} destroy ${dset}@vmsnap-${CBSD_MIGRNAME}-${prevCnt}" 2>/dev/null
+			${ZFS} destroy ${dset}@vmsnap-${CBSD_MIGRNAME}-${prevCnt} 2>/dev/null
+			#let prevCnt=prevCnt-1
+			prevCnt=$(( prevCnt - 1 ))
+		done
+	fi
+done
+
+${RM} -f /tmp/.vmmigrator.$$
+
+# Disable VM on SRC
+${ECHO} "${MAGENTA}* ${GREEN}Disabling instance on ${my_nodename}...${NORMAL}"
+
+case "${emulator}" in
+	jail)
+		jset jname=${jname} astart=0
+		;;
+	bhyve)
+		bset jname=${jname} astart=0
+		;;
+esac
+
+${ECHO} "${MAGENTA}* ${GREEN}Register instance on ${remote_node_name}...${NORMAL}"
+
+if [ ${full} -eq 1 ]; then
+
+	rexe node=${node} cbsd jregister jname=${jname}
+
+	if [ "${jail_status}" = "running" ]; then
+		${ECHO} "${MAGENTA}* ${GREEN}Run jail on ${node}${NORMAL}"
+		case "${emulator}" in
+			jail)
+				rexe node=${node} /usr/local/bin/cbsd jstart jname=${jname} inter=0
+				;;
+			bhyve)
+				rexe node=${node} /usr/local/bin/cbsd bstart jname=${jname} inter=0
+				;;
+		esac
+	fi
+fi
+
+
+ETIME=`${DATE} +%s`
+ENDTIME=`${DATE}`
+
+clear_stfile
+echo ""
+printf "\n                    ===   Done! ===\n"
+printf "\n   >> ${emulator} instance:  ${jname} (${host_hostname})"
+printf "\n          is now installed on\n"
+echo "   >> dest node:  ${remote_node_name} (${dest_vm_name})"
+echo ""
+echo "    Migration started:  ${BEGTIME}"
+echo "      Migration ended:  ${ENDTIME}"
+
+TDIFF=`expr ${ETIME} - ${STTIME}`
+if [ ${TDIFF} -gt 3600 ]; then
+	TDIFF=`echo "scale=2; ${TDIFF}/3600" | ${BC}`
+	TDIFF="${TDIFF} hours"
+elif [ ${TDIFF} -gt 60 ]; then
+	TDIFF=`echo "scale=2; ${TDIFF}/60" | ${BC}`
+	TDIFF="${TDIFF} minutes"
+else
+	TDIFF="${TDIFF} seconds"
+fi
+DIFFT=`expr ${ETIME} - ${DTIME}`
+if [ ${DIFFT} -gt 3600 ]; then
+	DIFFT=`echo "scale=2; ${DIFFT}/3600" | ${BC}`
+	DIFFT="${DIFFT} hours"
+elif [ ${DIFFT} -gt 60 ]; then
+	DIFFT=`echo "scale=2; ${DIFFT}/60" | ${BC}`
+	DIFFT="${DIFFT} minutes"
+else
+	DIFFT="${DIFFT} seconds"
+fi
+
+echo "Duration of migration:  ${TDIFF}"
+echo "    Instance downtime:  ${DIFFT}"
+echo "       Migration type:  ${migrType}"
+
+cntIncr=$(( cntIncr + 1 ))
+echo "   Dataset increments:  ${cntIncr}"
+if [ ${incr} -gt 0 ]; then
+	echo "   migration log file:  ${DC_NAME}:${LOGFILE}"
+fi
+
+#
+# Migration Summary - Originating node
+#
+
+echo "          Source node:  ${my_nodename} (${source_vm_name})"
+echo
+
+if [ ${aremove} -eq 0 -o ${aremove} -eq 1 ]; then
+	# store original ALWAYS_ and inter settings
+	OALWAYS_YES=${ALWAYS_YES}
+	OALWAYS_NO=${ALWAYS_NO}
+	ointer=${inter}
+	inter=0
+	unset ALWAYS_YES
+	unset ALWAYS_NO
+
+	case ${aremove} in
+		0)
+			ALWAYS_NO=1
+			;;
+		1)
+			ALWAYS_YES=1
+			;;
+	esac
+fi
+
+# Ask user if they would like to cleanup now...
+if getyesno "Would you like to remove this instance from ${my_nodename} now? "; then
+	if [ "${emulator}" = "bhyve" ]; then
+		bremove jname=${jname}
+		#echo "* ${ZFS} destroy -r ${LOCAL_ZROOT}/bcbsd-${jname}-dsk1.vhd"
+		#(${ZFS} destroy -r ${LOCAL_ZROOT}/bcbsd-${jname}-dsk1.vhd && echo "  ...success") || echo "  ...FAILED."
+		#echo "* ${ZFS} destroy -r ${LOCAL_ZROOT}/bcbsd-${jname}-dsk2.vhd\""
+		#(${ZFS} destroy -r ${LOCAL_ZROOT}/bcbsd-${jname}-dsk2.vhd && echo "  ...success") || echo "  ...FAILED."
+	else
+		jremove jname=${jname}
+		#echo "* ${ZFS} destroy -r ${LOCAL_ZROOT}/${jname}"
+		#(${ZFS} destroy -r ${LOCAL_ZROOT}/${jname} && echo "  ...success") || echo "  ...FAILED."
+	fi
+else
+	echo "    The source node should be cleaned of this VM.              "
+	echo ""
+	echo "    - To finish removing the VM from the source (${my_nodename}):      "
+	echo ""
+	if [ "${emulator}" = "bhyve" ]; then
+		echo "      bremove jname=${jname}"
+		echo "    or"
+		echo "      ${SSH} ${remote_node_ip} \"${ZFS} destroy -r ${LOCAL_ZROOT}/bcbsd-${jname}-dsk0.vhd\" &&"
+		echo "      ${SSH} ${remote_node_ip} \"${ZFS} destroy -r ${LOCAL_ZROOT}/bcbsd-${jname}-dsk1.vhd\" &&"
+	else
+		echo "      jremove jname=${jname}"
+		echo "    or"
+		echo "      ${ZFS} destroy -r ${LOCAL_ZROOT}/${jname}"
+	fi
+	echo
+fi
+
+# restore original settings
+if [ ${aremove} -eq 0 -o ${aremove} -eq 1 ]; then
+	# store original ALWAYS_ and inter settings
+	ALWAYS_YES=${OALWAYS_YES}
+	ALWAYS_NO=${OALWAYS_NO}
+	inter=${ointer}
+fi
+
+
+echo
+exit 0

--- a/upgrade/post-patch-11.1.3.0
+++ b/upgrade/post-patch-11.1.3.0
@@ -1,0 +1,37 @@
+#!/bin/sh
+#v11.1.3
+# This patch insert small1 packages into vmpackage table
+: ${distdir="/usr/local/cbsd"}
+unset workdir
+unset nodename
+
+# MAIN
+. /etc/rc.conf
+
+[ -z "${cbsd_workdir}" ] && exit
+[ ! -f "${cbsd_workdir}/nc.inventory" ] && exit
+
+workdir="${cbsd_workdir}"
+
+[ ! -f "${workdir}/cbsd.conf" ] && exit
+
+. ${distdir}/cbsd.conf
+. ${distdir}/tools.subr
+test_sql_stuff
+
+[ ! -f "${inventory}" ] && exit
+
+. ${inventory}
+
+[ -z "${nodename}" ] && exit
+
+CBSD=$( which cbsd )
+
+[ -z "${CBSD}" ] && exit
+
+_test=$( ${miscdir}/sqlcli ${dbdir}/local.sqlite "SELECT name FROM vmpackages WHERE name=\"small1\" LIMIT 1" )
+
+if [ -z "${_test}" ]; then
+	echo "  * Insert small1 group into vmpackage table"
+	${miscdir}/sqlcli ${dbdir}/local.sqlite "INSERT INTO vmpackages ( name, pkg_vm_cpus, pkg_vm_ram, pkg_vm_disk ) VALUES ( 'small1', '1', '1g', '10g' )"
+fi

--- a/upgrade/pre-patch-11.1.3.0
+++ b/upgrade/pre-patch-11.1.3.0
@@ -1,0 +1,37 @@
+#!/bin/sh
+#v11.1.3
+# Remove broken vmpackage schema
+: ${distdir="/usr/local/cbsd"}
+unset workdir
+unset nodename
+
+# MAIN
+. /etc/rc.conf
+
+[ -z "${cbsd_workdir}" ] && exit
+[ ! -f "${cbsd_workdir}/nc.inventory" ] && exit
+
+workdir="${cbsd_workdir}"
+
+[ ! -f "${workdir}/cbsd.conf" ] && exit
+
+. ${distdir}/cbsd.conf
+. ${distdir}/tools.subr
+test_sql_stuff
+
+[ ! -f "${inventory}" ] && exit
+
+. ${inventory}
+
+[ -z "${nodename}" ] && exit
+
+CBSD=$( which cbsd )
+
+[ -z "${CBSD}" ] && exit
+
+_test=$( ${miscdir}/sqlcli ${dbdir}/local.sqlite "SELECT timestamp FROM vmpackages LIMIT 1" )
+
+if [ -z "${_test}" ]; then
+	echo "  * Migrate vmpackages sql schema"
+	${miscdir}/sqlcli ${dbdir}/local.sqlite DROP TABLE IF EXISTS vmpackages
+fi


### PR DESCRIPTION
- [bj]login support for external custom command via [bj]login.conf config file
- freejname: also check remote nodes databases
- add facter instance variables for external hooks command:
    ${ipv4_first_public} ${ipv4_first_private} ${ipv4_first}
    ${ipv6_first_public} ${ipv6_first_private} ${ipv6_first}
- add vmpackages: grouped settings for vm
- add zfs-migrator: ZFS-based cloning instances between ZFS nodes,
  at the moment without integration with jcoldmigrate and work only
  via root ssh connection. Issue #118 also participates here