### PR TITLE
rollback for /usr/local/bin/cbsd before jexec

### DIFF
--- a/jcreate.subr
+++ b/jcreate.subr
@@ -67,20 +67,11 @@ external_exec_script()
 	[ -d "${data}/tmp/${_dir}" ] && /bin/rm -rf "${data}/tmp/${_dir}"
 	/bin/cp -a "${jailsysdir}/${jname}/${_dir}" ${data}/tmp/${_dir}
 
-	local CBSDPATH="${PATH}"
-	# reset CBSD PATH
-	# it is necessary that the calling of any commands from external hooks
-	# does not conflict with the same CBSD commands that the user does not expect
-	export PATH="/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin"
-
 	/usr/bin/find "${data}/tmp/${_dir}" \( -type l -or -type f \) -and \( -perm +111 \) -depth 1 -maxdepth 1 -exec /usr/bin/basename {} \; | while read _file; do
 		${ECHO} "${MAGENTA}Execute script: ${GREEN}${_file}${NORMAL}"
-		/usr/local/bin/cbsd jexec jname="${jname}" /tmp/${_dir}/${_file}
+		jexec jname="${jname}" /tmp/${_dir}/${_file}
 	done
 	/bin/rm -rf "${data}/tmp/${_dir}"
-
-	# restore CBSD PATH
-	export PATH="${CBSDPATH}"
 }
 
 # users custom stop for executing in master host
@@ -128,20 +119,12 @@ external_exec_script()
 	[ -d "${data}/tmp/${_dir}" ] && rm -rf "${data}/tmp/${_dir}"
 	/bin/cp -a "${jailsysdir}/${jname}/${_dir}" ${data}/tmp/${_dir}
 
-	local CBSDPATH="${PATH}"
-	# reset CBSD PATH
-	# it is necessary that the calling of any commands from external hooks
-	# does not conflict with the same CBSD commands that the user does not expect
-	export PATH="/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin"
-
 	/usr/bin/find "${data}/tmp/${_dir}" \( -type l -or -type f \) -and \( -perm +111 \) -depth 1 -maxdepth 1 -exec /usr/bin/basename {} \; | while read _file; do
 		${ECHO} "${MAGENTA}Execute script: ${GREEN}${_file}${NORMAL}"
-		/usr/local/bin/cbsd jexec jname="${jname}" /tmp/${_dir}/${_file}
+		jexec jname="${jname}" /tmp/${_dir}/${_file}
 	done
 
 	/bin/rm -rf "${data}/tmp/${_dir}"
-	# restore CBSD PATH
-	export PATH="${CBSDPATH}"
 }
 
 # users custom stop for executing in master host
@@ -266,31 +249,15 @@ exec_poststart()
 	eval CMD=\${exec_poststart}
 	[ -z "${CMD}" -o "${CMD}" = "0" ] && return 0
 
-	local CBSDPATH="${PATH}"
-	# reset CBSD PATH
-	# it is necessary that the calling of any commands from external hooks
-	# does not conflict with the same CBSD commands that the user does not expect
-	export PATH="/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin"
-
 	${ECHO} "${MAGENTA}${jname} exec exec_poststart: ${GREEN}${CMD}${NORMAL}"
-	/usr/local/bin/cbsd jexec jname=${jname} ${CMD}
-	# restore CBSD PATH
-	export PATH="${CBSDPATH}"
+	jexec jname=${jname} ${CMD}
 }
 
 exec_cbsdjail_first_boot()
 {
 	if [ -f ${path}/etc/rc.cbsdjail_first_boot ]; then
-		local CBSDPATH="${PATH}"
-		# reset CBSD PATH
-		# it is necessary that the calling of any commands from external hooks
-		# does not conflict with the same CBSD commands that the user does not expect
-		export PATH="/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin"
-
-		/usr/local/bin/cbsd jexec jname=${jname} /bin/sh /etc/rc.cbsdjail_first_boot
+		jexec jname=${jname} /bin/sh /etc/rc.cbsdjail_first_boot
 		/bin/rm -f ${path}/etc/rc.cbsdjail_first_boot
-		# restore CBSD PATH
-		export PATH="${CBSDPATH}"
 	fi
 }
 
@@ -316,16 +283,8 @@ exec_prestart()
 	eval CMD=\${exec_prestart}
 	[ -z "${CMD}" -o "${CMD}" = "0" ] && return 0
 
-	local CBSDPATH="${PATH}"
-	# reset CBSD PATH
-	# it is necessary that the calling of any commands from external hooks
-	# does not conflict with the same CBSD commands that the user does not expect
-	export PATH="/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin"
-
 	${ECHO} "${MAGENTA}${jname} exec exec_prestart: ${GREEN}${CMD}${NORMAL}"
-	/usr/local/bin/cbsd jexec jname=${jname} ${CMD}
-	# restore CBSD PATH
-	export PATH="${CBSDPATH}"
+	jexec jname=${jname} ${CMD}
 }
 
 export_bhyve_data_for_external_hook()


### PR DESCRIPTION
We dont need to restore PATH here due to cbsd shell will override it anyway.
We need to overwrite PATH only for master hook execution, not for jexec.  Issue #197