### PR TITLE
Preserve jconf perms

### DIFF
--- a/jailctl/jcreate
+++ b/jailctl/jcreate
@@ -84,7 +84,7 @@ temprcconf="${ftmpdir}/jcreate_jconf.$$"
 
 # TRIM DOS CRLF
 /bin/cat ${jconf} |/usr/bin/tr -d \\r > ${temprcconf}
-/bin/cp -a ${temprcconf} ${jconf}
+/bin/cat ${temprcconf} >${jconf}
 
 if [ ${removejconf} = "1" ]; then
 	trap "/bin/rm -f ${temprcconf} ${jconf}" HUP INT ABRT BUS TERM  EXIT


### PR DESCRIPTION
As `temprcconf` is generated with user running jcreate, original `jconf` perms are overwritten by cp