### PR TITLE
makeresolv: add optional nameserver and path args for independency

### DIFF
--- a/sudoexec/initenv
+++ b/sudoexec/initenv
@@ -283,6 +283,10 @@ phase2()
 	installne "-s -o ${cbsduser} -g ${cbsduser} -m 555" ${distdir}/tools/imghelper ${toolsdir}/imghelper
 	[ -f ${distdir}/tools/imghelper ] && /bin/rm -f ${distdir}/tools/imghelper
 
+	[ ! -f "${distdir}/tools/racctd-statsd" ] && ${CC_CMD} ${distdir}/tools/src/racct-statsd.c -lutil -lprocstat -ljail -lsqlite3 -I/usr/local/include -L/usr/local/lib -o ${distdir}/tools/racct-statsd
+	installne "-s -o ${cbsduser} -g ${cbsduser} -m 555" ${distdir}/tools/racct-statsd ${toolsdir}/racct-statsd
+	[ -f ${distdir}/tools/racct-statsd ] && /bin/rm -f ${distdir}/tools/racct-statsd
+
 	if [ "${platform}" != "DragonFly" ]; then
 		[ ! -f "${distdir}/tools/vale-ctl" ] && ${CC_CMD} ${distdir}/tools/src/vale-ctl.c -o ${distdir}/tools/vale-ctl
 		installne "-s -o ${cbsduser} -g ${cbsduser} -m 555" ${distdir}/tools/vale-ctl ${toolsdir}/vale-ctl
@@ -642,6 +646,11 @@ phase5()
 
 	[ $? -ne 0 ] && err 1 "Error for unconfigured query"
 
+	if [ -n "${INITCFG}" ]; then
+		. ${INITCFG}
+		_uncfg=$( ${GREP_CMD} -v '^#' ${INITCFG} | /usr/bin/cut -d '=' -f1 | /usr/bin/xargs )
+	fi
+
 	for _checkme in ${_uncfg}; do
 		for _uninit in ${USERINI}; do
 			# skip for nodename which is already set
@@ -657,6 +666,12 @@ phase5()
 					${miscdir}/sqlcli ${dbdir}/local.sqlite UPDATE local SET hammer=\"0\"
 					continue
 				fi
+
+				# check for pre-defined variables
+				T=
+				eval T="\$$_checkme"
+				[ -n "${T}" ] && export ${_checkme}_default="${T}"
+
 				desc_question ${_checkme}
 				[ $? -ne 0 ] && continue
 				# todo: input validation here
@@ -980,7 +995,6 @@ if [ $# -ne 1 ]; then
 fi
 
 [ -n "${INITCFG}" -a -r "${INITCFG}" ] && . ${INITCFG}
-
 
 set -e
 . ${distdir}/cbsd.conf

--- a/tools/makeresolv
+++ b/tools/makeresolv
@@ -1,8 +1,11 @@
 #!/usr/local/bin/cbsd
-#v10.1.6
+#v11.1.11
 globalconf="${workdir}/cbsd.conf";
 MYARG="jname"
+MYOPTARG="file nameserver"
 MYDESC="Prepare resolv.conf in jail"
+ADDHELP="file - path to resolv.conf to put him into jail\n\
+nameserver - IP address(es), comma-separated if multiple, e.g: nameserver=8.8.8.8,8.8.4.4\n"
 
 set -e
 . ${globalconf}
@@ -18,16 +21,23 @@ set_resolvconf()
 	local _i
 	local _tpl="CBSD makeresolv function"
 
-	local IFS=","
+	local IFS
 
-	for _i in ${jnameserver}; do
-		IFS=" "
-		iptype ${_i}
-		[ $? -eq 0 ] && continue
-		echo "nameserver ${_i}   # ${_tpl}" >> ${data}/etc/resolv.conf
+	if [ -n "${nameserver}" -o -z "${file}" ]; then
 		IFS=","
-	done
-	IFS=" "
+		for _i in ${jnameserver}; do
+			IFS=" "
+			iptype ${_i}
+			[ $? -eq 0 ] && continue
+			echo "nameserver ${_i}   # ${_tpl}" >> ${data}/etc/resolv.conf
+			IFS=","
+		done
+		IFS=" "
+	else
+		# just copy file
+		[ ! -r "${file}" ] && err 1 "${MAGENTA}makeresolv: unable to read ${GREEN}${file}${NORMAL}"
+		/bin/cp -a ${file} ${data}/etc/resolv.conf
+	fi
 }
 
 
@@ -35,15 +45,23 @@ unset_resolvconf()
 {
 	local _tpl="CBSD makeresolv function"
 
-	if ${GREP_CMD} "${_tpl}" ${data}/etc/resolv.conf >/dev/null 2>&1; then
+	if [ -n "${nameserver}" -o -z "${file}" ]; then
+		# nameserver if preferr to file
+		if ${GREP_CMD} "${_tpl}" ${data}/etc/resolv.conf >/dev/null 2>&1; then
+			/bin/cp -a ${data}/etc/resolv.conf ${data}/etc/resolv.conf.bak
+			${GREP_CMD} -v "${_tpl}" ${data}/etc/resolv.conf.bak |${GREP_CMD} "." > ${data}/etc/resolv.conf
+		fi
+	else
+		# just copy file
 		/bin/cp -a ${data}/etc/resolv.conf ${data}/etc/resolv.conf.bak
-		${GREP_CMD} -v "${_tpl}" ${data}/etc/resolv.conf.bak |${GREP_CMD} "." > ${data}/etc/resolv.conf
 	fi
 }
 
 
 . ${jrcconf}
 [ $? -eq 1 ] && err 1 "${MAGENTA}No such jail: ${GREEN}${jname}${NORMAL}"
+
+[ -n "${nameserver}" ] && jnameserver="${nameserver}"
 
 unset_resolvconf
 set_resolvconf


### PR DESCRIPTION
initenv: support for pre-defined config for re-configure

makeresolv now support optional args:
  cbsd makeresolv file=<path-to-resolv.conf>
  cbsd makeresolv nameserver=8.8.8.8
  cbsd makeresolv nameserver=8.8.4.4,8.8.8.8

for independent configuration of jails /etc/resolv.conf

initenv: fast hack to support pre-defined variables from config file for re-configure, e.g:

cat > /tmp/initenv.conf << EOF
jnameserver="8.8.8.8,8.8.4.4"
nodeip="192.168.0.1"
EOF

cbsd initenv inter=0 /tmp/initenv.conf