### PR TITLE
remove hardcode version for HBSD: cast and use major version for repo…

### DIFF
--- a/HardenedBSD.subr
+++ b/HardenedBSD.subr
@@ -1,0 +1,17 @@
+if [ ! "$_CBSD_FREEBSD_SUBR" ]; then
+_CBSD_FREEBSD_SUBR=1
+###
+
+SYSRC_CMD="/usr/sbin/sysrc"
+HOST_CMD="/usr/bin/host"
+PFCTL_CMD="/sbin/pfctl"
+PKG_CMD="/usr/sbin/pkg"
+CHFLAGS_CMD="/bin/chflags"
+
+PKG_DEFAULT_REPO="repo-HardenedBSD.sqlite"
+
+MOUNT_NULL_CMD="/sbin/mount_nullfs"
+NULLFS="nullfs"
+
+###
+fi

--- a/cbsd.conf
+++ b/cbsd.conf
@@ -112,6 +112,8 @@ fi
 [ -f "${inventory}" ] && . ${inventory}
 # Load _CMD variable: Default and custom by platform name
 [ -z "${platform}" ] && platform=$( uname -s )
+# Overwrite $platform to HardenedBSD if we have /usr/sbin/hbsd-update:
+[ -e "/usr/sbin/hbsd-update" ] && platform="HardenedBSD"
 [ -f "${workdir}/cmd.subr" ] && . ${workdir}/cmd.subr
 [ -f "${workdir}/${platform}.subr" ] && . ${workdir}/${platform}.subr
 

--- a/etc/defaults/vm-dflybsd-x86-4.conf
+++ b/etc/defaults/vm-dflybsd-x86-4.conf
@@ -45,7 +45,9 @@ vm_efi="uefi"
 vm_vnc_port="0"
 
 # disable profile?
-active=1
+xen_active=1
+bhyve_active=1
+
 # Available in ClonOS?
 clonos_active=1
 

--- a/etc/defaults/vm-dflybsd-x86-5.conf
+++ b/etc/defaults/vm-dflybsd-x86-5.conf
@@ -45,7 +45,9 @@ vm_efi="uefi"
 vm_vnc_port="0"
 
 # disable profile?
-active=1
+xen_active=1
+bhyve_active=1
+
 # Available in ClonOS?
 clonos_active=1
 

--- a/etc/defaults/vm-dflybsd-x86-latest.conf
+++ b/etc/defaults/vm-dflybsd-x86-latest.conf
@@ -39,7 +39,9 @@ vm_efi="uefi"
 vm_vnc_port="0"
 
 # disable profile?
-active=0
+xen_active=1
+bhyve_active=1
+
 # Available in ClonOS?
 clonos_active=0
 

--- a/etc/defaults/vm-freebsd-ArchBSD-x86_64-20140904.conf
+++ b/etc/defaults/vm-freebsd-ArchBSD-x86_64-20140904.conf
@@ -17,7 +17,8 @@ default_jailname="archbsd"
 imgsize="4g"
 
 # disable profile?
-active=0
+xen_active=0
+bhyve_active=0
 
 # VirtualBox Area
 virtualbox_ostype="FreeBSD_64"

--- a/etc/defaults/vm-freebsd-BSDRP-x64-1.80.conf
+++ b/etc/defaults/vm-freebsd-BSDRP-x64-1.80.conf
@@ -28,7 +28,8 @@ default_jailname="bsdrp"
 vm_package="small1"
 
 # disable profile?
-active=0
+xen_active=0
+bhyve_active=0
 
 # Available in ClonOS?
 clonos_active=0

--- a/etc/defaults/vm-freebsd-FreeBSD-bsdinstall-jail.conf
+++ b/etc/defaults/vm-freebsd-FreeBSD-bsdinstall-jail.conf
@@ -10,7 +10,8 @@ default_jailname="freebsd"
 imgsize="4g"
 
 # disable profile?
-active=0
+xen_active=0
+bhyve_active=0
 
 # Available in ClonOS?
 clonos_active=0

--- a/etc/defaults/vm-freebsd-FreeBSD-from-jail.conf
+++ b/etc/defaults/vm-freebsd-FreeBSD-from-jail.conf
@@ -14,7 +14,8 @@ vm_console="nmdm"
 ip4_addr="DHCP"
 
 # disable profile?
-active=1
+xen_active=0
+bhyve_active=0
 
 # Available in ClonOS?
 clonos_active=0

--- a/etc/defaults/vm-freebsd-FreeBSD-x64-10.3.conf
+++ b/etc/defaults/vm-freebsd-FreeBSD-x64-10.3.conf
@@ -25,7 +25,9 @@ default_jailname="freebsd"
 vm_package="small1"
 
 # disable profile?
-active=1
+xen_active=1
+bhyve_active=1
+
 # Available in ClonOS?
 clonos_active=1
 

--- a/etc/defaults/vm-freebsd-FreeBSD-x64-10.4.conf
+++ b/etc/defaults/vm-freebsd-FreeBSD-x64-10.4.conf
@@ -25,7 +25,9 @@ default_jailname="freebsd"
 vm_package="small1"
 
 # disable profile?
-active=1
+xen_active=1
+bhyve_active=1
+
 # Available in ClonOS?
 clonos_active=1
 

--- a/etc/defaults/vm-freebsd-FreeBSD-x64-11.0.conf
+++ b/etc/defaults/vm-freebsd-FreeBSD-x64-11.0.conf
@@ -24,7 +24,8 @@ register_iso_as="iso-FreeBSD-11.0-RELEASE-amd64-disc1"	# this is vm_iso_path in 
 default_jailname="freebsd"
 
 # disable profile?
-active=1
+xen_active=1
+bhyve_active=1
 
 # Available in ClonOS?
 clonos_active=1

--- a/etc/defaults/vm-freebsd-FreeBSD-x64-11.1.conf
+++ b/etc/defaults/vm-freebsd-FreeBSD-x64-11.1.conf
@@ -22,7 +22,9 @@ register_iso_as="iso-FreeBSD-11.1-RELEASE-amd64-disc1"	# this is vm_iso_path in 
 default_jailname="freebsd"
 
 # disable profile?
-active=1
+xen_active=1
+bhyve_active=1
+
 # Available in ClonOS?
 clonos_active=1
 

--- a/etc/defaults/vm-freebsd-FreeBSD-x64-12.0-LATEST.conf
+++ b/etc/defaults/vm-freebsd-FreeBSD-x64-12.0-LATEST.conf
@@ -17,7 +17,8 @@ register_iso_as="iso-FreeBSD-x64-12.0"
 default_jailname="freebsd"
 
 # disable profile?
-active=1
+xen_active=1
+bhyve_active=1
 
 # Available in ClonOS?
 clonos_active=0

--- a/etc/defaults/vm-freebsd-FreeNAS-x64-11.conf
+++ b/etc/defaults/vm-freebsd-FreeNAS-x64-11.conf
@@ -17,7 +17,8 @@ register_iso_as="iso-FreeNAS-x64-11.1"
 default_jailname="freenas"
 
 # disable profile?
-active=0
+xen_active=0
+bhyve_active=0
 
 # Available in ClonOS?
 clonos_active=0

--- a/etc/defaults/vm-freebsd-GhostBSD-x64-11.1.conf
+++ b/etc/defaults/vm-freebsd-GhostBSD-x64-11.1.conf
@@ -17,8 +17,8 @@ register_iso_as="iso-GhostBSD11.1-mate-amd64.iso"
 default_jailname="ghost"
 
 # disable profile?
-# not fully verified - loaded into multiuser
-active=1
+xen_active=0
+bhyve_active=0
 
 # Available in ClonOS?
 clonos_active=0

--- a/etc/defaults/vm-freebsd-HardenedBSD-x64-10-stable.conf
+++ b/etc/defaults/vm-freebsd-HardenedBSD-x64-10-stable.conf
@@ -16,7 +16,9 @@ register_iso_as="iso-HardenedBSD-10-stable"	# this is vm_iso_path in vm config
 default_jailname="hbsd"
 
 # disable profile?
-active=1
+xen_active=1
+bhyve_active=1
+
 # Available in ClonOS?
 clonos_active=1
 

--- a/etc/defaults/vm-freebsd-HardenedBSD-x64-11-stable.conf
+++ b/etc/defaults/vm-freebsd-HardenedBSD-x64-11-stable.conf
@@ -16,7 +16,9 @@ register_iso_as="iso-HardenedBSD-11-stable"	# this is vm_iso_path in vm config
 default_jailname="hbsd"
 
 # disable profile?
-active=1
+xen_active=1
+bhyve_active=1
+
 # Available in ClonOS?
 clonos_active=1
 

--- a/etc/defaults/vm-freebsd-MidnightBSD-amd64-0.8.6.conf
+++ b/etc/defaults/vm-freebsd-MidnightBSD-amd64-0.8.6.conf
@@ -19,8 +19,9 @@ register_iso_as="iso-MidnightBSD-release-0.8.6.iso"
 default_jailname="mbsd"
 
 # disable profile?
-# Not UEFI-ready yet
-active=0
+xen_active=0
+bhyve_active=0
+
 # Available in ClonOS?
 clonos_active=0
 

--- a/etc/defaults/vm-freebsd-NAS4Free-x64-11.conf
+++ b/etc/defaults/vm-freebsd-NAS4Free-x64-11.conf
@@ -20,7 +20,8 @@ vm_package="small1"
 #virtio_type="ahci-hd"
 
 # disable profile?
-active=0
+xen_active=0
+bhyve_active=0
 
 # VNC
 vm_vnc_port="0"

--- a/etc/defaults/vm-freebsd-OPNsense-17-RELEASE-amd64.conf
+++ b/etc/defaults/vm-freebsd-OPNsense-17-RELEASE-amd64.conf
@@ -32,7 +32,8 @@ default_jailname="opnsense"
 #virtio_type="ahci-hd"
 
 # disable profile?
-active=1
+xen_active=1
+bhyve_active=1
 
 # Available in ClonOS?
 clonos_active=1

--- a/etc/defaults/vm-freebsd-TrueOS-x64-latest-stable.conf
+++ b/etc/defaults/vm-freebsd-TrueOS-x64-latest-stable.conf
@@ -19,7 +19,8 @@ vm_package="small1"
 
 # disable: no mouse in VNC - need to investigation
 # disable profile?
-active=0
+xen_active=0
+bhyve_active=0
 
 # VNC
 vm_vnc_port="0"

--- a/etc/defaults/vm-freebsd-TrueOS-x64-latest-unstable.conf
+++ b/etc/defaults/vm-freebsd-TrueOS-x64-latest-unstable.conf
@@ -19,7 +19,8 @@ vm_package="small1"
 
 # disable: no mouse in VNC - need to investigation
 # disable profile?
-active=0
+xen_active=0
+bhyve_active=0
 
 # VNC
 vm_vnc_port="0"

--- a/etc/defaults/vm-freebsd-kFreeBSD-amd64-7.conf
+++ b/etc/defaults/vm-freebsd-kFreeBSD-amd64-7.conf
@@ -22,7 +22,8 @@ vm_efi="uefi"
 vm_package="small1"
 
 # disable profile?
-active=0
+xen_active=0
+bhyve_active=0
 
 # VirtualBox Area
 virtualbox_ostype="FreeBSD_64"

--- a/etc/defaults/vm-freebsd-kFreeBSD-amd64-8.conf
+++ b/etc/defaults/vm-freebsd-kFreeBSD-amd64-8.conf
@@ -23,7 +23,8 @@ vm_vnc_port="0"
 vm_efi="uefi"
 
 # disable profile?
-active=0
+xen_active=0
+bhyve_active=0
 
 # VirtualBox Area
 virtualbox_ostype="FreeBSD_64"

--- a/etc/defaults/vm-freebsd-pfSense-2-LATEST-amd64.conf
+++ b/etc/defaults/vm-freebsd-pfSense-2-LATEST-amd64.conf
@@ -25,7 +25,8 @@ imgsize="2g"
 #virtio_type="ahci-hd"
 
 # disable profile?
-active=0
+xen_active=1
+bhyve_active=1
 
 # Available in ClonOS?
 clonos_active=0

--- a/etc/defaults/vm-freebsd-pfSense-2-RELEASE-amd64.conf
+++ b/etc/defaults/vm-freebsd-pfSense-2-RELEASE-amd64.conf
@@ -32,7 +32,8 @@ register_iso_as="iso-${vm_profile}"
 #virtio_type="ahci-hd"
 
 # disable profile?
-active=1
+xen_active=1
+bhyve_active=1
 
 # Available in ClonOS?
 clonos_active=1

--- a/etc/defaults/vm-linux-ArchLinux-x86-2017.conf
+++ b/etc/defaults/vm-linux-ArchLinux-x86-2017.conf
@@ -45,7 +45,8 @@ vm_vnc_port="0"
 vm_efi="uefi"
 
 # disable profile?
-active=1
+xen_active=1
+bhyve_active=1
 
 # Available in ClonOS?
 clonos_active=0

--- a/etc/defaults/vm-linux-CentOS-6-x86_64.conf
+++ b/etc/defaults/vm-linux-CentOS-6-x86_64.conf
@@ -42,7 +42,8 @@ vm_vnc_port="0"
 vm_efi="uefi"
 
 # disable profile?
-active=1
+xen_active=1
+bhyve_active=1
 
 # Available in ClonOS?
 clonos_active=1

--- a/etc/defaults/vm-linux-CentOS-7.3-x86_64.conf
+++ b/etc/defaults/vm-linux-CentOS-7.3-x86_64.conf
@@ -42,7 +42,8 @@ vm_vnc_port="0"
 vm_efi="uefi"
 
 # disable profile?
-active=1
+xen_active=1
+bhyve_active=1
 
 # Available in ClonOS?
 clonos_active=1

--- a/etc/defaults/vm-linux-CentOS-7.4-x86_64.conf
+++ b/etc/defaults/vm-linux-CentOS-7.4-x86_64.conf
@@ -43,7 +43,8 @@ vm_vnc_port="0"
 vm_efi="uefi"
 
 # disable profile?
-active=1
+xen_active=1
+bhyve_active=1
 
 # Available in ClonOS?
 clonos_active=1

--- a/etc/defaults/vm-linux-CoreOS.conf
+++ b/etc/defaults/vm-linux-CoreOS.conf
@@ -34,5 +34,5 @@ vm_vnc_port="0"
 vm_efi="uefi"
 
 # disable profile?
-active=0
-
+xen_active=0
+bhyve_active=0

--- a/etc/defaults/vm-linux-Debian-x86-8.conf
+++ b/etc/defaults/vm-linux-Debian-x86-8.conf
@@ -36,7 +36,8 @@ vm_vnc_port="0"
 vm_efi="uefi"
 
 # disable profile?
-active=1
+xen_active=1
+bhyve_active=1
 
 # Available in ClonOS?
 clonos_active=1

--- a/etc/defaults/vm-linux-Debian-x86-9.conf
+++ b/etc/defaults/vm-linux-Debian-x86-9.conf
@@ -47,7 +47,8 @@ vm_vnc_port="0"
 vm_efi="uefi"
 
 # disable profile?
-active=1
+xen_active=1
+bhyve_active=1
 
 # Available in ClonOS?
 clonos_active=1

--- a/etc/defaults/vm-linux-Kali-2017-amd64.conf
+++ b/etc/defaults/vm-linux-Kali-2017-amd64.conf
@@ -30,7 +30,8 @@ vm_vnc_port="0"
 vm_efi="uefi"
 
 # disable profile?
-active=1
+xen_active=1
+bhyve_active=1
 
 # Available in ClonOS?
 clonos_active=1

--- a/etc/defaults/vm-linux-OracleLinux-7.conf
+++ b/etc/defaults/vm-linux-OracleLinux-7.conf
@@ -36,7 +36,8 @@ vm_vnc_port="0"
 vm_efi="uefi"
 
 # disable profile?
-active=1
+xen_active=1
+bhyve_active=1
 
 # Available in ClonOS?
 clonos_active=0

--- a/etc/defaults/vm-linux-RancherOS-latest.conf
+++ b/etc/defaults/vm-linux-RancherOS-latest.conf
@@ -33,7 +33,8 @@ vm_vnc_port="0"
 vm_efi="uefi"
 
 # disable profile?
-active=0
+xen_active=0
+bhyve_active=0
 
 # Available in ClonOS?
 clonos_active=0

--- a/etc/defaults/vm-linux-Tails-3.0.1.conf
+++ b/etc/defaults/vm-linux-Tails-3.0.1.conf
@@ -34,7 +34,8 @@ vm_vnc_port="0"
 vm_efi="uefi"
 
 # disable profile?
-active=0
+xen_active=0
+bhyve_active=0
 
 # Available in ClonOS?
 clonos_active=0

--- a/etc/defaults/vm-linux-TinyCore-x86-8.conf
+++ b/etc/defaults/vm-linux-TinyCore-x86-8.conf
@@ -39,7 +39,8 @@ vm_vnc_port="0"
 vm_efi="uefi"
 
 # disable profile?
-active=1
+xen_active=1
+bhyve_active=1
 
 # Available in ClonOS?
 clonos_active=0

--- a/etc/defaults/vm-linux-fedora-server-26-x86_64.conf
+++ b/etc/defaults/vm-linux-fedora-server-26-x86_64.conf
@@ -30,7 +30,8 @@ vm_vnc_port="0"
 vm_efi="uefi"
 
 # disable profile?
-active=1
+xen_active=1
+bhyve_active=1
 
 # Available in ClonOS?
 clonos_active=1

--- a/etc/defaults/vm-linux-fedora-server-27-x86_64.conf
+++ b/etc/defaults/vm-linux-fedora-server-27-x86_64.conf
@@ -30,7 +30,8 @@ vm_vnc_port="0"
 vm_efi="uefi"
 
 # disable profile?
-active=1
+xen_active=1
+bhyve_active=1
 
 # Available in ClonOS?
 clonos_active=1

--- a/etc/defaults/vm-linux-fedora-workstation-24-x86_64.conf
+++ b/etc/defaults/vm-linux-fedora-workstation-24-x86_64.conf
@@ -24,7 +24,9 @@ vm_efi="uefi"
 # disable profile?
 # Some fail on install stage, stale on: 
 # A start job is running for sys-device-virtual-misc-vmbus\x21hv_fcopy.device
-active=0
+# disable profile?
+xen_active=0
+bhyve_active=0
 
 # Available in ClonOS?
 clonos_active=0

--- a/etc/defaults/vm-linux-gentoo-amd64-2017.conf
+++ b/etc/defaults/vm-linux-gentoo-amd64-2017.conf
@@ -31,7 +31,8 @@ vm_vnc_port="0"
 vm_efi="uefi"
 
 # disable profile?
-active=1
+xen_active=1
+bhyve_active=1
 
 # Available in ClonOS?
 clonos_active=1

--- a/etc/defaults/vm-linux-kubuntu-x86-17.10.conf
+++ b/etc/defaults/vm-linux-kubuntu-x86-17.10.conf
@@ -1,8 +1,8 @@
 # don't remove this line:
-vm_profile="kubuntu-x86-16"
+vm_profile="kubuntu-x86-17.10"
 vm_os_type="linux"
 # this is one-string additional info strings in dialogue menu
-long_description="Linux KUbuntu LTS 16.04.3"
+long_description="Linux KUbuntu LTS 17.10.3"
 
 # custom settings:
 fetch=1
@@ -13,16 +13,19 @@ grub_boot_cmd="/usr/bin/lockf -s -t0 /tmp/bhyveload.${jname}.lock grub-bhyve -r 
 # grub-bhyve command to boot from ISO
 grub_iso_cmd="/usr/bin/lockf -s -t0 /tmp/bhyveload.${jname}.lock grub-bhyve -r cd0 -m ${_devicemap} -M ${grubmem} ${jname}"
 
-iso_site="http://cdimage.ubuntu.com/kubuntu/releases/16.04.3/release/ \
-http://www.mirrorservice.org/sites/cdimage.ubuntu.com/cdimage/kubuntu/releases/16.04.3/release/ \
-http://ftp.linux.org.tr/kubuntu/16.04.3/release/ \
+iso_site="http://cdimage.ubuntu.com/kubuntu/releases/17.10.1/release/ \
+http://www.mirrorservice.org/sites/cdimage.ubuntu.com/cdimage/kubuntu/releases/17.10.1/release/ \
+http://ftp.linux.org.tr/kubuntu/17.10.1/release/ \
+http://se.cdimage.ubuntu.com/kubuntu/releases/17.10.1/release/ \
+http://www.mirrorservice.org/sites/cdimage.ubuntu.com/cdimage/kubuntu/releases/17.10.1/release/ \
+http://ftp.linux.org.tr/kubuntu/17.10.1/release \
 "
 
-iso_img="kubuntu-16.04.3-desktop-amd64.iso"
+iso_img="kubuntu-17.10.1-desktop-amd64.iso"
 
 # register_iso as:
 register_iso_name="cbsd-iso-${iso_img}"
-register_iso_as="iso-kubuntu-16.04.3"
+register_iso_as="iso-kubuntu-17.10.1"
 
 default_jailname="kubuntu"
 
@@ -36,8 +39,7 @@ vm_vnc_port="0"
 vm_efi="uefi"
 
 # disable profile?
-xen_active=1
-bhyve_active=1
+active=1
 
 # Available in ClonOS?
 clonos_active=1

--- a/etc/defaults/vm-linux-opennode-6.x86_64.conf
+++ b/etc/defaults/vm-linux-opennode-6.x86_64.conf
@@ -25,7 +25,8 @@ imgsize="8g"
 boot_from_grub=1
 
 # disable profile?
-active=0
+xen_active=0
+bhyve_active=0
 
 # Available in ClonOS?
 clonos_active=0

--- a/etc/defaults/vm-linux-opensuse-x86-42.conf
+++ b/etc/defaults/vm-linux-opensuse-x86-42.conf
@@ -39,7 +39,8 @@ vm_vnc_port="0"
 vm_efi="uefi"
 
 # disable profile?
-active=1
+xen_active=1
+bhyve_active=1
 
 # Available in ClonOS?
 clonos_active=1

--- a/etc/defaults/vm-linux-ubuntuserver-x86-16.04.conf
+++ b/etc/defaults/vm-linux-ubuntuserver-x86-16.04.conf
@@ -46,7 +46,8 @@ vm_vnc_port="0"
 vm_efi="uefi"
 
 # disable profile?
-active=1
+xen_active=1
+bhyve_active=1
 
 # Available in ClonOS?
 clonos_active=1

--- a/etc/defaults/vm-linux-ubuntuserver-x86-17.04.conf
+++ b/etc/defaults/vm-linux-ubuntuserver-x86-17.04.conf
@@ -46,7 +46,8 @@ vm_vnc_port="0"
 vm_efi="uefi"
 
 # disable profile?
-active=1
+xen_active=1
+bhyve_active=1
 
 # Available in ClonOS?
 clonos_active=1

--- a/etc/defaults/vm-netbsd-x86-7.conf
+++ b/etc/defaults/vm-netbsd-x86-7.conf
@@ -37,7 +37,8 @@ vm_vnc_port="0"
 vm_efi="uefi"
 
 # disable profile?
-active=0
+xen_active=1
+bhyve_active=0
 
 # Available in ClonOS?
 clonos_active=0

--- a/etc/defaults/vm-openbsd-x86-6.conf
+++ b/etc/defaults/vm-openbsd-x86-6.conf
@@ -42,7 +42,8 @@ vm_vnc_port="0"
 vm_efi="uefi"
 
 # disable profile?
-active=1
+xen_active=1
+bhyve_active=1
 
 # Available in ClonOS?
 clonos_active=1

--- a/etc/defaults/vm-other-FreeDOS.conf
+++ b/etc/defaults/vm-other-FreeDOS.conf
@@ -25,7 +25,8 @@ vm_efi="uefi_csm"
 bhyve_vnc_vgaconf="off"           # vgaconf
 
 # disable profile?
-active=1
+xen_active=1
+bhyve_active=0
 
 # Available in ClonOS?
 clonos_active=0

--- a/etc/defaults/vm-other-Haiku-R1Alpha-4.1.conf
+++ b/etc/defaults/vm-other-Haiku-R1Alpha-4.1.conf
@@ -23,7 +23,8 @@ register_iso_as="iso-${vm_profile}"
 #virtio_type="ahci-hd"
 
 # disable profile?
-active=1
+xen_active=1
+bhyve_active=0
 
 # Available in ClonOS?
 clonos_active=0

--- a/etc/defaults/vm-other-Minix_R3.3.0.conf
+++ b/etc/defaults/vm-other-Minix_R3.3.0.conf
@@ -23,7 +23,8 @@ register_iso_as="iso-${vm_profile}"
 #virtio_type="ahci-hd"
 
 # disable profile?
-active=1
+xen_active=1
+bhyve_active=0
 
 # Available in ClonOS?
 clonos_active=0

--- a/etc/defaults/vm-other-Minoca.conf
+++ b/etc/defaults/vm-other-Minoca.conf
@@ -24,7 +24,8 @@ vm_package="small1"
 virtio_type="virtio-blk"
 
 # disable profile?
-active=0
+xen_active=0
+bhyve_active=0
 
 # Available in ClonOS?
 clonos_active=0

--- a/etc/defaults/vm-other-OSX.conf
+++ b/etc/defaults/vm-other-OSX.conf
@@ -17,7 +17,8 @@ vm_package="small1"
 virtio_type="ahci-hd"
 
 # disable profile?
-active=0
+xen_active=0
+bhyve_active=0
 
 # Available in ClonOS?
 clonos_active=0

--- a/etc/defaults/vm-other-ReactOS.conf
+++ b/etc/defaults/vm-other-ReactOS.conf
@@ -27,7 +27,8 @@ register_iso_name="cbsd-iso-${iso_img}"
 register_iso_as="iso-${vm_profile}"
 
 # disable profile?
-active=0
+xen_active=0
+bhyve_active=0
 
 # Available in ClonOS?
 clonos_active=0

--- a/etc/defaults/vm-other-SmartOS.conf
+++ b/etc/defaults/vm-other-SmartOS.conf
@@ -17,7 +17,8 @@ default_jailname="smartos"
 virtio_type="ahci-hd"
 
 # disable profile?
-active=1
+xen_active=1
+bhyve_active=1
 
 # Available in ClonOS?
 clonos_active=0

--- a/etc/defaults/vm-other-hackintosh.conf
+++ b/etc/defaults/vm-other-hackintosh.conf
@@ -15,7 +15,8 @@ default_jailname="hackintosh"
 virtio_type="ahci-hd"
 
 # disable profile?
-active=0
+xen_active=0
+bhyve_active=0
 
 # Available in ClonOS?
 clonos_active=0

--- a/etc/defaults/vm-other-mavericks.conf
+++ b/etc/defaults/vm-other-mavericks.conf
@@ -23,7 +23,8 @@ register_iso_name="cbsd-iso-${iso_img}"
 register_iso_as="iso-${vm_profile}"
 
 # disable profile?
-active=0
+xen_active=0
+bhyve_active=0
 
 # Available in ClonOS?
 clonos_active=0

--- a/etc/defaults/vm-other-openindiana-2017.conf
+++ b/etc/defaults/vm-other-openindiana-2017.conf
@@ -41,7 +41,9 @@ vm_efi="uefi"
 
 # UEFI not supported
 # disable profile?
-active=0
+# disable profile?
+xen_active=0
+bhyve_active=0
 
 # Available in ClonOS?
 clonos_active=0

--- a/etc/defaults/vm-other-solaris-11.conf
+++ b/etc/defaults/vm-other-solaris-11.conf
@@ -31,7 +31,9 @@ vm_efi="uefi"
 
 # disable profile?
 # Doesn't boot or loading too long after greetings
-active=0
+# disable profile?
+xen_active=0
+bhyve_active=0
 
 # Available in ClonOS?
 clonos_active=0

--- a/etc/defaults/vm-windows-10_86x_64x.conf
+++ b/etc/defaults/vm-windows-10_86x_64x.conf
@@ -19,7 +19,8 @@ virtio_type="ahci-hd"
 #virtio_type="virtio-blk"
 
 # disable profile?
-active=1
+xen_active=1
+bhyve_active=1
 
 # Available in ClonOS?
 clonos_active=1

--- a/etc/defaults/vm-windows-8_86x_64x.conf
+++ b/etc/defaults/vm-windows-8_86x_64x.conf
@@ -23,7 +23,8 @@ vm_vnc_port="0"
 vm_efi="uefi"
 
 # disable profile?
-active=1
+xen_active=1
+bhyve_active=1
 
 # Available in ClonOS?
 clonos_active=0

--- a/jailctl/jexport
+++ b/jailctl/jexport
@@ -130,6 +130,8 @@ else
 	shift
 fi
 
+[ -z "${jname}" -a -n "${1}" ] && jname="${1}"
+
 if [ -n "${jname}" ]; then
 
 	case "${ls}" in

--- a/settings-tui.subr
+++ b/settings-tui.subr
@@ -1771,7 +1771,7 @@ get_construct_vm_os_profile()
 
 	_all=0
 
-	eval $( env NOCOLOR=1 show_profile_list search_profile=${_search_profile} only_active=1 uniq=1 display=path,name,contrib header=0 |while read path vm_profile contrib; do
+	eval $( env NOCOLOR=1 show_profile_list search_profile=${_search_profile} show_${emulator}=1 uniq=1 display=path,name,contrib header=0 |while read path vm_profile contrib; do
 		unset long_description
 		eval $( ${GREP_CMD} ^long_description= ${path} )
 		[ -z "${long_description}" ] && long_description="${vm_profile}"

--- a/sudoexec/jstart
+++ b/sudoexec/jstart
@@ -341,6 +341,13 @@ fi
 init_target_arch
 init_basedir
 
+if [ ${baserw} -eq 0 ]; then
+	if [ -r "${BASE_DIR_LOCKFILE}" ]; then
+		locked_by=$( /bin/cat ${BASE_DIR_LOCKFILE} )
+		err 1 "${MAGENTA}basedir locked: ${GREEN}${BASE_DIR}${MAGENTA}, by pid: ${GREEN}${locked_by}${MAGENTA}. Please try later${NORMAL}"
+	fi
+fi
+
 jcleanup jname=${jname}
 [ ! -d "${path}" ] && /bin/mkdir ${path}
 

--- a/system/installworld
+++ b/system/installworld
@@ -37,6 +37,9 @@ init_basedir
 LOCKFILE=${ftmpdir}/$( /sbin/md5 -qs ${MAKEOBJDIRPREFIX} ).lock
 makelock ${LOCKFILE} "cleanup_bases"
 
+# make base lock
+echo $$ > ${BASE_DIR_LOCKFILE}
+
 #  work-around for:
 # rm -rf /tmp/install.PazxMxWt
 # make[2]: "/usr/jails/src/src_11/src/share/mk/bsd.compiler.mk" line 37: Unable to determine compiler type for cc.  Consider setting COMPILER_TYPE.
@@ -74,3 +77,5 @@ baseelf=$( ${miscdir}/elf_tables --ver ${BASE_DIR}/bin/sh 2>/dev/null )
 
 [ -z "${baseelf}" ] && baseelf="0"
 register_base
+
+/bin/rm -f ${BASE_DIR_LOCKFILE}

--- a/system/removebase
+++ b/system/removebase
@@ -50,6 +50,9 @@ init_srcdir
 
 LOCKFILE=${ftmpdir}/$( /sbin/md5 -qs ${MAKEOBJDIRPREFIX} ).lock
 
+# make base lock
+echo $$ > ${BASE_DIR_LOCKFILE}
+
 # CBSD QUEUE
 if [ -x "${moduledir}/cbsd_queue.d/cbsd_queue" ]; then
 	[ "${cbsd_queue_name}" != "none" ] && cbsd_queue_sys cbsd_queue_name=${cbsd_queue_name} cmd=removebase id=base${ver}-${arch}-${stable} status=1
@@ -76,10 +79,12 @@ if  on_mounted "${BASE_DIR}"; then
 	err 1 "${MAGENTA}Current dir in use. Please unmount first ${GREEN}${BASE_DIR}${NORMAL}:\n$(/sbin/mount |grep ^${BASE_DIR})"
 fi
 
-makelock $LOCKFILE
+makelock ${LOCKFILE} "cleanup_bases"
 ${CHFLAGS_CMD} -R noschg ${BASE_DIR}
 /bin/rm -rf ${BASE_DIR}
 unregister_base
+
+[ -r ${BASE_DIR_LOCKFILE} ] && /bin/rm -f ${BASE_DIR_LOCKFILE}
 
 # CBSD QUEUE
 if [ -x "${moduledir}/cbsd_queue.d/cbsd_queue" ]; then

--- a/tools/repo
+++ b/tools/repo
@@ -138,7 +138,7 @@ register_fetched_base()
 
 getbase()
 {
-	local _srcmd5_found _src_found
+	local _srcmd5_found _src_found _majorver
 
 	if [ -z "${basename}" ]; then
 		BDIR="${basejailpref}_${arch}_${ver}"
@@ -146,19 +146,27 @@ getbase()
 		BDIR="${basejailpref}_${basename}_${arch}_${ver}"
 	fi
 
-	if [ -e "/usr/sbin/hbsd-update" ]; then
-		MIRROR="https://fourdots.com/mirror/HardenedBSD"
-		FHIER="${arch}/${target_arch}/hardenedbsd-11-stable-LAST"
-		BSDBASE_DISTSITE="$MIRROR/HardenedBSD/releases/${FHIER}/base.txz"
-	else
-		MIRROR="http://ftp.freebsd.org"
-		FHIER="${arch}/${target_arch}/${ver}"
-		BSDBASE_DISTSITE="$MIRROR/pub/FreeBSD/releases/${FHIER}-RELEASE/base.txz"
-	fi
-
+	case "${platform}" in
+		DragonFly)
+			err 1 "${MAGENTA}${platform} unsupported yet${NORMAL}"
+			;;
+		FreeBSD)
+			MIRROR="http://ftp.freebsd.org"
+			FHIER="${arch}/${target_arch}/${ver}"
+			BSDBASE_DISTSITE="$MIRROR/pub/FreeBSD/releases/${FHIER}-RELEASE/base.txz"
+			;;
+		HardenedBSD)
+			# Assume HBSD always in stable=1: at the moment (2018-01-17) doesn't have
+			# /hardenedbsd-X.Y- url. So, adduct ver version to major version for repo hier
+			_majorver=${ver%%.*}
+			MIRROR="https://fourdots.com/mirror/HardenedBSD"
+			FHIER="${arch}/${target_arch}/hardenedbsd-${_majorver}-stable-LAST"
+			BSDBASE_DISTSITE="$MIRROR/HardenedBSD/releases/${FHIER}/base.txz"
+			;;
+	esac
 
 	if [ -x "${BASE_DIR}/bin/sh" ]; then
-		[ $upgrade -eq 1 ] || err 1 "${MAGENTA}You already have ${ver}. Use mode=upgrade for upgrade${NORMAL}"
+		[ ${upgrade} -eq 1 ] || err 1 "${MAGENTA}You already have ${ver}. Use mode=upgrade for upgrade${NORMAL}"
 		${CHFLAGS_CMD} -R noschg ${BASE_DIR}
 	fi
 
@@ -189,7 +197,7 @@ getbase()
 
 	if [ "$fbsdrepo" = "1" -a -z "${basename}" ]; then
 		## Official fbsd repo
-		${ECHO} "${MAGENTA}Looking for official FreeBSD mirror:${NORMAL}"
+		${ECHO} "${MAGENTA}Looking for official ${platform} mirror:${NORMAL}"
 		ARCHIVE="$MYDIR/base.txz"
 		fetchme -u ${BSDBASE_DISTSITE} -o ${ARCHIVE}
 		if [ $? -eq 0 ]; then
@@ -202,7 +210,7 @@ getbase()
 			/bin/rm -f ${ARCHIVE}
 			# fetch lib32 only for amd64
 			if [ "${arch}" = "amd64" ]; then
-				if [ ! -e "/usr/sbin/hbsd-update" ]; then
+				if [ "${platform}" = "FreeBSD" ]; then
 					BSDBASE_DISTSITE="$MIRROR/pub/FreeBSD/releases/${FHIER}-RELEASE/lib32.txz"
 					ARCHIVE="$MYDIR/lib32.txz"
 					fetchme -u ${BSDBASE_DISTSITE} -o ${ARCHIVE}
@@ -213,10 +221,10 @@ getbase()
 						/usr/bin/tar xfz ${ARCHIVE}
 						set +e
 						/bin/rm -f ${ARCHIVE}
-                    			else
-                        			printf "${GREEN} Lib32 not found${NORMAL}\n"
-	                    		fi
-        	        	fi
+					else
+						printf "${GREEN} Lib32 not found${NORMAL}\n"
+					fi
+				fi
 			fi
 			preparebase dst=${BASE_DIR}
 			register_fetched_base
@@ -710,8 +718,11 @@ case "${action}" in
 				# makelock $LOCKFILE "rm -f ${TF}; /bin/rm -rf ${MYDIR}" safe
 				init_basedir
 				init_kerneldir
-				trap "rm -f ${TF}; /bin/rm -rf ${MYDIR}"
-				mkdir -p ${MYDIR}
+
+				# make base lock
+				echo $$ > ${BASE_DIR_LOCKFILE}
+				trap "rm -f ${TF} ${BASE_DIR_LOCKFILE}; /bin/rm -rf ${MYDIR}"
+				/bin/mkdir -p ${MYDIR}
 				getbase
 				;;
 			"obj")

--- a/tools/show_profile_list
+++ b/tools/show_profile_list
@@ -1,13 +1,14 @@
 #!/usr/local/bin/cbsd
-#v11.1.3
+#v11.1.12
 MYARG="search_profile"
-MYOPTARG="display header active uniq only_active"
+MYOPTARG="display header active uniq show_bhyve show_xen"
 MYDESC="Operate with bhyve disk images and database"
 CBSDMODULE="sys"
 ADDHELP="search_profile= - prefix for filename, e.g: vm-${vm_os_type}, ${emulator}-freebsd- \n\
 header=0 don't print header\n\
 display= list by comma for column: path,name,active,contrib. Default: path,name,active\n\
-only_active=0,1,2 show only active=0 (disabled), 1-(enabled) and 2 - (any). default is: 2\n\
+show_bhyve=0,1,2 show only active=0 (disabled), 1-(enabled) and 2 - (any). default is: 2\n\
+show_xen=0,1,2 show only active=0 (disabled), 1-(enabled) and 2 - (any). default is: 2\n\
 uniq=0,1 - 0 (default) - show all profiles, 1 - sort uniq by name with ~cbsd/etc/ win over ~cbsd/etc/defaults\n"
 
 . ${subr}
@@ -17,15 +18,18 @@ uniq=0,1 - 0 (default) - show all profiles, 1 - sort uniq by name with ~cbsd/etc
 
 init $*
 
+[ -z "${show_bhyve}" ] && show_bhyve=0
+[ -z "${show_xen}" ] && show_xen=0
 [ -z "${uniq}" ] && uniq=0
 [ -z "${display}" ] && display="path,name,active"
-[ -z "${only_active}" ] && only_active=2
+[ -z "${only_bhyve_active}" ] && only_bhyve_active=2
+[ -z "${only_xen_active}" ] && only_xen_active=2
 
 #remove commas for loop action on header
-mydisplay=$(echo ${display} |/usr/bin/tr ',' '  ')
+mydisplay=$( echo ${display} | /usr/bin/tr ',' '  ' )
 
 # upper for header
-myheader=$(echo ${mydisplay} |/usr/bin/tr '[:lower:]' '[:upper:]')
+myheader=$( echo ${mydisplay} | /usr/bin/tr '[:lower:]' '[:upper:]' )
 
 show_header()
 {
@@ -90,17 +94,20 @@ show_jaildata_from_sql()
 	done
 
 	for _i in ${_tmp_profile_list}; do
-		eval $( ${GREP_CMD} -E "(^jail_profile=)|(^vm_profile=)|(^active=)" ${_i} )
+		vm_profile=
+		bhyve_active=0
+		xen_active=0
+		eval $( ${GREP_CMD} -E "(^jail_profile=)|(^vm_profile=)|(^bhyve_active=)|(^xen_active=)" ${_i} )
+		[ -z "${vm_profile}" ] && continue
 		path="${_i}"
-		[ -z "${active}" ] && active="0"
+		[ -z "${xen_active}" ] && xen_active=0
+		[ -z "${bhyve_active}" ] && bhyve_active="99"
 		[ -n "${jail_profile}" ] && name="${jail_profile}"
 		[ -n "${vm_profile}" ] && name="${vm_profile}"
 
-		case ${only_active} in
+		case "${show_bhyve}" in
 			0|1)
-				[ "${active}" != "${only_active}" ] && continue
-				;;
-			2)
+				[ "${bhyve_active}" != "${show_bhyve}" ] && continue
 				;;
 		esac
 

--- a/universe.subr
+++ b/universe.subr
@@ -59,7 +59,7 @@ init_srcdir()
 	fi
 }
 
-# init BASE_DIR. After init_target_arch only
+# init BASE_DIR and BASE_DIR_LOCKFILE. After init_target_arch only
 # require: $arch, $target_arch, $ver
 # optional: $basename, $destdir
 # SKIP_CHECK_DIR=1 - do not exit if dir not exist, just init path variable
@@ -81,6 +81,8 @@ init_basedir()
 	else
 		BASE_DIR="${basejaildir}/${basejailpref}_${_basename}_${arch}_${target_arch}_${ver}"
 	fi
+
+	BASE_DIR_LOCKFILE="${BASE_DIR}.lock"
 }
 
 
@@ -378,6 +380,8 @@ cleanup_bases()
 	else
 		unregister_base
 	fi
+
+	[ -r "${BASE_DIR_LOCKFILE}" ] && /bin/rm -f ${BASE_DIR_LOCKFILE}
 }
 
 ###

--- a/virtual.subr
+++ b/virtual.subr
@@ -79,7 +79,7 @@ init_iso()
 			for i in ${iso_site}; do
 				url="${i}${iso_img_dist}"
 #				${ECHO} "${MAGENTA} :: ${url}"
-				printf " ${MAGENTA}* ${GREEN}${i}${NORMAL}: "
+				printf " ${WHITE}* ${GREEN}${i}${NORMAL}: "
 				t_size=$( /usr/bin/timeout -s HUP 3 ${bindir}/cfetch -s 1 -o /dev/null -u ${url} 2>/dev/null )
 				if [ -z "${t_size}" ]; then
 					echo "failed"


### PR DESCRIPTION
… hier;

Identify HBSD environment with platform="HardenedBSD" global variable;
show_profile_list: separate filter by show_xen/show_bhyve instead if active=;
jexport: possibility to specify jname as $1 arg;
add lock file for base_dir:
  Better handling of the situation when the base directory is in the modification mode;
  And add check for base lock upon jail start.
  This prevents the situation when first jail started downloading new base and second
  jail started in parallel trying to downloading the same base in same time