### PR TITLE
* fix for inter=0 at nat framework question

### DIFF
--- a/etc/defaults/vm-freebsd-FreeBSD-x64-12.0-LATEST.conf
+++ b/etc/defaults/vm-freebsd-FreeBSD-x64-12.0-LATEST.conf
@@ -8,7 +8,7 @@ long_description="FreeBSD 12.0 Current"
 fetch=1
 
 iso_site="https://download.freebsd.org/ftp/snapshots/amd64/amd64/ISO-IMAGES/12.0/ ftp://ftp.freebsd.org/pub/FreeBSD/snapshots/amd64/amd64/ISO-IMAGES/12.0/"
-iso_img="FreeBSD-12.0-CURRENT-amd64-20180131-r328637-disc1.iso"
+iso_img="FreeBSD-12.0-CURRENT-amd64-20180208-r329009-disc1.iso"
 
 # register_iso as:
 register_iso_name="cbsd-iso-${iso_img}"

--- a/initenv.subr
+++ b/initenv.subr
@@ -151,7 +151,7 @@ make_nat()
 			return 0
 			;;
 		"pf")
-			if [ $( /usr/bin/grep ^pf_load= /boot/loader.conf| /usr/bin/wc -l ) = 0 ]; then
+			if [ $( /usr/bin/grep ^pf_load= /boot/loader.conf 2>/dev/null | /usr/bin/wc -l ) = 0 ]; then
 				getyesno "Do you want to modify /boot/loader.conf to set pf_load=YES ?" && ${SYSRC_CMD} -vf /boot/loader.conf pf_load=YES
 			fi
 
@@ -207,7 +207,7 @@ EOF
 			local check_mod="net.inet.ip.fw.default_to_accept ipfw_nat_load libalias_load"
 			local fix_mod=0
 			for i in ${check_mod}; do
-				/usr/bin/grep -q ^${i} /boot/loader.conf || fix_mod=$(( fix_mod + 1 ))
+				/usr/bin/grep -q ^${i} /boot/loader.conf 2>/dev/null || fix_mod=$(( fix_mod + 1 ))
 			done
 
 			if [ ${fix_mod} -ne 0 ]; then
@@ -219,7 +219,7 @@ EOF
 				fi
 			fi
 			/usr/bin/truncate -s0 ${etcdir}/ipfw.conf
-			_nm=$( echo ${rfc1918} |/usr/bin/tr " " "," )
+			_nm=$( echo ${rfc1918} | /usr/bin/tr " " "," )
 			/bin/cat >> ${etcdir}/ipfw.conf << EOF
 /sbin/ipfw -q add ${fwcount_end} nat 123 all from ${_nm} to not ${_nm} any via ${_extiface}
 /sbin/ipfw -q nat 123 config ip ${natip}
@@ -263,7 +263,12 @@ configure_nat()
 	while [ "${nat_selected}" != "1" ]; do
 		${ECHO} "${BOLD}Which NAT framework do you want to use: [${GREEN}${_default}${NORMAL}${BOLD}]${NORMAL}"
 		${ECHO} "${MAGENTA}(type FW name, eg pf,ipfw,ipfilter, 'disable' or '0' to CBSD NAT, \"exit\" for break)${NORMAL}"
-		read ok leftover
+
+		# skip reading answer when inter=0
+		if [ "${inter}" != "0" ]; then
+			read ok leftover
+		fi
+
 		[ -z "${ok}" ] && ok="${_default}"
 
 		case "${ok}" in
@@ -428,7 +433,7 @@ configure_racct()
 		return 0
 	fi
 
-	if [ $( /usr/bin/grep ^kern.racct.enable /boot/loader.conf ${workdir}/rc.conf | /usr/bin/wc -l ) = 0 ]; then
+	if [ $( /usr/bin/grep ^kern.racct.enable /boot/loader.conf ${workdir}/rc.conf 2>/dev/null | /usr/bin/wc -l ) = 0 ]; then
 		if getyesno "Do you want to enable RACCT feature for resource accounting?"; then
 			${SYSRC_CMD} -qf /boot/loader.conf kern.racct.enable=1
 		else

--- a/jailctl/jsetup-tui
+++ b/jailctl/jsetup-tui
@@ -133,6 +133,7 @@ allow_tmpfs allow_zfs allow_kmem mount_kernel mount_obj protected hidden allow_r
 	done
 
 	menu_list="${menu_list} '-'		'-'	''"
+	menu_list="${menu_list} 'jailnic'	'Network config >>'	'cbsd jailnic-tui.'"
 	menu_list="${menu_list} 'jrctl'		'Rrtl config >>'	'cbsd jrctl-tui'"
 	menu_list="${menu_list} 'order'		'Boot order >>'		'cbsd jorder-tui'"
 	menu_list="${menu_list} '-'		'-'	''"
@@ -227,6 +228,9 @@ while [ 1 ]; do
 		interface)
 			get_construct_interface -d 1 -s "tap bridge vboxnet"
 			continue
+			;;
+		"jailnic")
+			jailnic-tui jname=${jname}
 			;;
 		*)
 			get_construct_${mychoice}

--- a/settings-tui.subr
+++ b/settings-tui.subr
@@ -1695,24 +1695,30 @@ get_construct_imgtype()
 }
 
 
-# form for $arch
+# form for $vm_os_type
+# if $1 = "value" apply value without dialog
 get_construct_vm_os_type()
 {
 	local _input
 	local defaultitem="${vm_os_type}"
 
-	unset menu_list
-
-	# load menu_list from external source by emulator opportunity
-	if [ -f "${sharedir}/emulators/ostype_${emulator}.subr" ]; then
-		. ${sharedir}/emulators/ostype_${emulator}.subr
+	if [ -n "${1}" ]; then
+		vm_os_type="${1}"
+		retval=${DIALOG_OK}
 	else
-		f_dialog_msgbox "No such menu_list for emulator ${emulator}:\n${sharedir}/emulators/ostype_${emulator}.subr"
-		return 0
-	fi
+		unset menu_list
 
-	cbsd_menubox
-	retval=$?
+		# load menu_list from external source by emulator opportunity
+		if [ -f "${sharedir}/emulators/ostype_${emulator}.subr" ]; then
+			. ${sharedir}/emulators/ostype_${emulator}.subr
+		else
+			f_dialog_msgbox "No such menu_list for emulator ${emulator}:\n${sharedir}/emulators/ostype_${emulator}.subr"
+			return 0
+		fi
+
+		cbsd_menubox
+		retval=$?
+	fi
 
 	case $retval in
 		${DIALOG_OK})
@@ -1815,12 +1821,16 @@ get_construct_vm_os_profile()
 
 	[ -z "${menu_list}" ] && unset vm_os_profile && return 0
 
-	defaultitem="${vm_os_profile}"
+	if [ -n "${1}" ]; then
+		mtag="${1}"
+		retval=${DIALOG_OK}
+	else
+		defaultitem="${vm_os_profile}"
+		cbsd_menubox
+		retval=$?
+	fi
 
-	cbsd_menubox
-	retval=$?
-
-	case $retval in
+	case ${retval} in
 		${DIALOG_OK})
 			pkgnum=0
 			unset pkglist tpl_pkglist from_jail vm_profile profile

--- a/share/initenv.conf
+++ b/share/initenv.conf
@@ -1,16 +1,30 @@
 # This is sample of initenv scenatio for non-interactive first setup of cbsd
-cbsd_password="cbsdpw"
-nodename="dev.my.domain"
+# sample:
+# /usr/local/cbsd/sudoexec/initenv inter=0 /usr/local/cbsd/share/initenv.conf
+#
+# nodename="auto"        - use 'hostname' values, valid value sample: cbsd1.my.domain
+# nodeip="auto"          - use first ip/nic values, valid value sample: 10.0.0.5
+# natip="auto"           - use default gateway NIC, valid value sample: 're0', 'igb0', '10.0.0.5'
+# jail_interface="auto"  - use default gateway NIC
+# stable="auto"          - inherits hoster version, e.g: if 12.2 than stable='0', when 12-STABLE or 13-CURRENT: stable='1'
+#
 
-nodeip="192.168.1.100"
+nodename="auto"
+nodeip="auto"
 jnameserver="8.8.8.8 8.8.4.4"
 nodeippool="10.0.0.0/24"
-natip="192.168.1.100"
+natip="auto"
 nat_enable="pf"
-
 mdtmp="8"
 ipfw_enable="1"
 zfsfeat="1"
 hammerfeat="0"
+fbsdrepo="1"
+repo="http://bsdstore.ru"
+workdir="/usr/jails"
+jail_interface="auto"
+parallel="5"
+stable="auto"
+
 # experimental
 statsd_enable="0"

--- a/tools/bconstruct-tui
+++ b/tools/bconstruct-tui
@@ -231,9 +231,20 @@ f_dialog_title "$msg_system_console_configuration"
 f_dialog_backtitle "${ipgm:+bsdconfig }$pgm"
 f_mustberoot_init
 
-vm_iso_path="${register_iso_as}"
-
-apply_vm_package
+if [ "${default_profile}" = "default" -a -r ${tmpdir}/bconstruct.conf ]; then
+	. ${tmpdir}/bconstruct.conf
+	if [ -n "${last_vm_os_type}" ]; then
+		vm_os_type="${last_vm_os_type}"
+		get_construct_vm_os_type ${vm_os_type}
+	fi
+	if [ -n "${last_vm_os_profile}" ]; then
+		vm_os_profile="${last_vm_os_profile}"
+		get_construct_vm_os_profile ${vm_os_profile}
+	fi
+else
+	vm_iso_path="${register_iso_as}"
+	apply_vm_package
+fi
 
 while [ 1 ]; do
 	pkgnum=0
@@ -257,6 +268,9 @@ while [ 1 ]; do
 			exit 0
 			;;
 		"GO")
+			# store last choices
+			sysrc -qf ${tmpdir}/bconstruct.conf last_vm_os_type="${vm_os_type}" > /dev/null 2>&1
+			sysrc -qf ${tmpdir}/bconstruct.conf last_vm_os_profile="${vm_os_profile}" > /dev/null 2>&1
 			gen_newjail_conf
 			;;
 		"-")

--- a/tools/jconstruct-tui
+++ b/tools/jconstruct-tui
@@ -1,5 +1,5 @@
 #!/usr/local/bin/cbsd
-#v10.1.5
+#v11.1.5
 MYARG=""
 MYOPTARG="mode"
 MYDESC="Ncurses based jail creation wizard"
@@ -157,6 +157,14 @@ f_mustberoot_init
 
 . ${workdir}/universe.subr
 
+if [ "${default_profile}" = "default" -a -r ${tmpdir}/jconstruct.conf ]; then
+	. ${tmpdir}/jconstruct.conf
+	if [ -n "${last_profile}" ]; then
+		profile="${last_profile}"
+		get_construct_profile ${profile}
+	fi
+fi
+
 adduser=
 zfs_snapsrc=
 nic_hwaddr=0
@@ -186,6 +194,8 @@ while [ 1 ]; do
 			exit 0
 			;;
 		"GO")
+			# store last choices
+			sysrc -qf ${tmpdir}/jconstruct.conf last_profile="${profile}" > /dev/null 2>&1
 			gen_newjail_conf
 			;;
 		baserw|astart|applytpl|floatresolv|mount_ports|vnet|pkg_bootstrap)


### PR DESCRIPTION
when /usr/local/cbsd/sudoexec/initenv inter=0 <path_file> used, skip read on
  NAT framework choosing when non-interactive flags used

* [jb]consturct-tui: store previous profile choices