### PR TITLE
impove jexport part

### DIFF
--- a/bin/cbsdsh/about.h
+++ b/bin/cbsdsh/about.h
@@ -1,1 +1,1 @@
-#define VERSION "11.1.17a"
+#define VERSION "11.1.17b"

--- a/cbsd.conf
+++ b/cbsd.conf
@@ -3,7 +3,7 @@ unset oarch over ostable arch target_arch ver stable
 
 # defines
 product="CBSD"
-myversion="11.1.17a"
+myversion="11.1.17b"
 
 if [ -z "${workdir}" ]; then
 	echo "no workdir"

--- a/cbsd.lua
+++ b/cbsd.lua
@@ -1,5 +1,5 @@
 product="CBSD"
-myversion="11.1.17a"
+myversion="11.1.17b"
 
 if not workdir then
 	print ( "no workdir" )

--- a/jailctl/jexport
+++ b/jailctl/jexport
@@ -2,15 +2,13 @@
 #v11.1.6
 globalconf="${workdir}/cbsd.conf";
 MYARG=""
-MYOPTARG="jname compress imgname ls"
+MYOPTARG="jname compress imgname ls dstdir"
 MYDESC="Export jail into image"
 CBSDMODULE="jail"
 ADDHELP="ls - filter for list: bls or jls\n\
-compress - XZ compress level ( 0 - 9 ). Default is: 6. 0 mean is compression disabled\n"
-
-set -e
-. ${globalconf}
-set +e
+compress - XZ compress level ( 0 - 9 ). Default is: 6. 0 mean is compression disabled\n\
+imgname - alternative image dir ( by default - $jname.img\n\
+dstdir - alternative export dir ( by default - $workdir/exports )\n"
 
 . ${subr}
 . ${strings}
@@ -18,10 +16,14 @@ set +e
 
 init $*
 
+# ClonOS ws channel
+[ -z "${cbsd_queue_name}" ] && cbsd_queue_name="/clonos/jailscontainers/"
+[ -z "${cbsd_queue_name2}" ] && cbsd_queue_name2="/clonos/imported/"
+
 jexport_me()
 {
 	${ECHO} "${MAGENTA}Exporting (with compress level:${GREEN}${compress}${MAGENTA}), please stand by: ${GREEN}${jname}${NORMAL}"
-	local DEST="${exportdir}/${imgname}"
+	local DEST="${dstdir}/${imgname}"
 	local JAILRCCONF="${jailsysdir}/${jname}/rc.conf_${jname}"
 
 	jmkrcconf jname=${jname} > ${JAILRCCONF}
@@ -123,6 +125,8 @@ ___NCSTART_DATA=1"
 }
 
 [ -z "${compress}" ] && compress=6
+[ -z "${dstdir}" ] && dstdir="${exportdir}"
+[ ! -d "${dstdir}" ] && /bin/mkdir -p ${dstdir}
 
 if [ -z "${ls}" ]; then
 	ls="jls"
@@ -170,7 +174,38 @@ if [ ${jid} -ne 0 -a "${emulator}" = "bhyve" ]; then
 	err 1 "${MAGENTA}VM is online${NORMAL}"
 fi
 
+# CBSD QUEUE
+if [ -x "${moduledir}/cbsd_queue.d/cbsd_queue" ]; then
+
+	case "${emulator}" in
+		jail)
+			cbsd_queue_name="/clonos/jailscontainers/"
+			;;
+		bhyve)
+			cbsd_queue_name="/clonos/bhyvevms/"
+			;;
+	esac
+
+	[ "${cbsd_queue_name}" != "none" ] && cbsd_queue cbsd_queue_name=${cbsd_queue_name} id=${jname} cmd=jexport status=1
+
+	if [ "${cbsd_queue_name2}" != "none" ]; then
+		cbsd_queue cbsd_queue_name=${cbsd_queue_name2} cmd=message msg="{\"id\":\"${jname}.img\",\"cmd\":\"jexport\",\"status\":\"1\",\"data\":{\"node\":\"local\",\"jname\":\"${jname}.img\",\"imptype\":\"${emulator}\"}}"
+		cbsd_queue cbsd_queue_name=${cbsd_queue_name2} cmd=message msg="{\"cmd\":\"tooltip\",\"type\":\"information\",\"timeout\":10000,\"author\":\"Export\",\"msg\":\"${jname}#export#started...\"}"
+	fi
+fi
+
 jexport_me
 ret=$?
+
+# CBSD QUEUE
+if [ -x "${moduledir}/cbsd_queue.d/cbsd_queue" ]; then
+
+	[ "${cbsd_queue_name}" != "none" ] && cbsd_queue cbsd_queue_name=${cbsd_queue_name} id=${jname} cmd=jexport status=2
+
+	if [ "${cbsd_queue_name2}" != "none" ]; then
+		cbsd_queue cbsd_queue_name=${cbsd_queue_name2} cmd=message msg="{\"id\":\"${jname}.img\",\"cmd\":\"jexport\",\"status\":\"2\",\"data\":{\"node\":\"local\",\"jname\":\"${jname}.img\",\"imptype\":\"${emulator}\"}}"
+		cbsd_queue cbsd_queue_name=${cbsd_queue_name2} cmd=message msg="{\"cmd\":\"tooltip\",\"type\":\"success\",\"timeout\":10000,\"author\":\"Export\",\"msg\":\"${jname}#export#completed\"}"
+	fi
+fi
 
 exit ${ret}

--- a/jailctl/jimport
+++ b/jailctl/jimport
@@ -12,10 +12,6 @@ new_host_hostname= - change hostname while importing. By default, domain is inhe
    from original with change of hostname.\n"
 CBSDMODULE="jail"
 
-set -e
-. ${globalconf}
-set +e
-
 . ${subr}
 . ${tools}
 init $*
@@ -138,8 +134,20 @@ ${SYSRC_CMD} -qf ${JAILRCCONF} mount_fstab=${jailfstabdir}/${jailfstabpref}${jna
 ${SYSRC_CMD} -qf ${JAILRCCONF} data=${jaildatadir}/${jname}-${jaildatapref} >/dev/null
 ${SYSRC_CMD} -qf ${JAILRCCONF} rcconf=${jailrcconfdir}/${jname}-rcconf >/dev/null
 
+. ${JAILRCCONF}
+
 # CBSD QUEUE
 if [ -x "${moduledir}/cbsd_queue.d/cbsd_queue" ]; then
+
+	case "${emulator}" in
+		jail)
+			cbsd_queue_name="/clonos/jailscontainers/"
+			;;
+		bhyve)
+			cbsd_queue_name="/clonos/bhyvevms/"
+			;;
+	esac
+
 	[ "${cbsd_queue_name}" != "none" ] && cbsd_queue cbsd_queue_name=${cbsd_queue_name} id=${jname} cmd=jcreate ip4_addr=unknown protected=${protected} vnc_port=0 status=1
 	if [ "${cbsd_queue_name2}" != "none" ]; then
 		cbsd_queue cbsd_queue_name=${cbsd_queue_name2} id=${jname} cmd=jimport status=1
@@ -147,7 +155,6 @@ if [ -x "${moduledir}/cbsd_queue.d/cbsd_queue" ]; then
 	fi
 fi
 
-. ${JAILRCCONF}
 
 init_jail_path
 

--- a/tools/imgpart
+++ b/tools/imgpart
@@ -1,5 +1,5 @@
 #!/usr/local/bin/cbsd
-#v10.1.0
+#v16.1.17
 MYARG="jname part mode"
 MYOPTARG="out hdrver compress emulator"
 MYDESC="Pack or extract chunk from from image"
@@ -31,11 +31,13 @@ extractchunk()
 		0)
 			[ -z "${out}" ] && out="/dev/stdout"
 			imghelper --start ${FROM} --end ${TO} --infile ${SRC} --outfile ${out}
+			[ $? -ne 0 ] && err 1 "${MAGENTA}imghelper error${NORMAL}"
 			echo >> ${out}
 			;;
 		1)
 			[ -z "${out}" ] && out=$( /bin/pwd )
 			imghelper --start ${FROM} --end ${TO} --infile ${SRC} | /usr/bin/tar xpf - -C "${out}" --numeric-owner
+			[ $? -ne 0 ] && err 1 "${MAGENTA}imghelper error${NORMAL}"
 			;;
 	esac
 

--- a/tools/imgremove
+++ b/tools/imgremove
@@ -1,0 +1,45 @@
+#!/usr/local/bin/cbsd
+#v11.1.17
+globalconf="${workdir}/cbsd.conf";
+MYARG="path"
+MYOPTARG="jname img"
+MYDESC="Remove CBSD image from directory"
+ADDHELP="jname= image name without .img postfix\n\
+img= basename of file (with postfix, e.g: jail1.img\n"
+CBSDMODULE="sys"
+
+. ${subr}
+. ${tools}
+init $*
+
+. ${system}
+
+[ -z "${cbsd_queue_name}" ] && cbsd_queue_name="/clonos/imported/"
+
+[ -z "${jname}" -a -z "${img}" ] && err 1 "${MAGENTA}Please specify ${GREEN}jname=${MAGENTA} or ${GREEN}img=${NORMAL}"
+
+dirpath=$( /bin/realpath ${path} )
+
+## todo: check for safe dir list ( export, import, jail_imported )
+
+if [ -n "${jname}" ]; then
+	fname="${jname}.img"
+else
+	fname="${img}"
+fi
+
+imgpath="${dirpath}/${fname}"
+
+[ ! -r "${imgpath}" ] && err 1 "${MAGENTA}no such ${GREEN}${imgpath}${NORMAL}"
+
+imgpart out=/tmp/hdr.$$ jname=${imgpath} part=header mode=extract
+
+ret=$?
+
+/bin/rm -f hdr.$$
+
+[ ${ret} -ne 0 ] && err 1 "${MAGENTA}Unable to get header: ${GREEN}${imgpath}${MAGENTA}. Not CBSD image?${NORMAL}"
+
+/bin/rm -f ${imgpath}
+
+exit 0

--- a/tools/src/imghelper.c
+++ b/tools/src/imghelper.c
@@ -46,6 +46,8 @@ int main(int argc, char *argv[])
 	int win = FALSE;
 	int optcode = 0;
 	int option_index = 0, ret = 0;
+	int is_header=0;		//search for first MByte only
+	off_t total_bytes;		//bytes processed
 
 	static struct option long_options[] = {
 		{"start", required_argument, 0, C_START_SIGN},
@@ -81,6 +83,8 @@ int main(int argc, char *argv[])
 				st = malloc(strlen(optarg) + 1);
 				memset(st, 0, strlen(optarg) + 1);
 				strcpy(st, optarg);
+				if (!strcmp(st,"___NCSTART_HEADER=1"))
+					is_header=1;		// we are looking header only at the beginning
 				break;
 			case C_HELP:
 				usage();
@@ -110,7 +114,14 @@ int main(int argc, char *argv[])
 	while ( hammer!= 2 ) {
 
 		c=getc(fp);
+		total_bytes++;
 		if (feof(fp)) break;
+
+		if ((is_header==1)&&(total_bytes > 1048576)) {
+			fclose(fp);
+			printf("no header in first 1048576 bytes. Not CBSD image?\n");
+			exit(1);
+		}
 
 		switch (hammer) {
 			case 0:


### PR DESCRIPTION
* jexport: add dstdir
  alternative directory for saving images;
* jexport: support for wss notification for ClonOS
* added tools/imgremove: script for safe removal CBSD images:
     - we check that the file is an image of CBSD before deleting.
     This script is mainly used by the ClonOS because it does not
     have the right to delete files.
* imghelper.c micro optimization: we search for the header only in
  the first 1MB. If header signature is not detected - error 1.
  This speeds up the validation of large files that are not CBSD images