### PR TITLE
fetch_iso: sort mirror by fastest resource

### DIFF
--- a/virtual.subr
+++ b/virtual.subr
@@ -39,6 +39,8 @@ init_iso()
 {
 	local sha256sum_new
 	local sha256sum_passed
+	local _sorted_mirror_list
+	local _sorted_mirror_list_rate
 
 	if [ -z "${iso_img}" ]; then
 		${ECHO} "no cd: iso_img and register_iso_as is empty"
@@ -116,12 +118,17 @@ init_iso()
 			local url=
 
 			${ECHO} "${MAGENTA}Scanning for fastest mirror...${NORMAL}"
-			for i in ${iso_site} ${cbsd_iso_mirrors}; do
+
+			_sorted_mirror_list=$( for i in ${iso_site} ${cbsd_iso_mirrors}; do echo $i; done | /usr/bin/sort -u )
+			_sorted_mirror_list_rate=
+
+			for i in ${_sorted_mirror_list}; do
 				url="${i}${iso_img_dist}"
 				printf " ${WHITE}* ${GREEN}${i}${NORMAL}: "
 				t_size=$( /usr/bin/timeout -s HUP 3 ${bindir}/cfetch -s 1 -o /dev/null -u ${url} 2>/dev/null )
 				if [ -z "${t_size}" ]; then
 					echo "failed"
+					t_size=0
 				else
 					echo "${t_size}"
 					if ! is_number ${t_size}; then
@@ -130,13 +137,20 @@ init_iso()
 							win_mirror="${i}"
 						fi
 					else
+						t_size=0
 						echo "failed, no size"
 					fi
 				fi
+				_sorted_mirror_list_rate="${_sorted_mirror_list_rate}${t_size} ${i}\n"
 			done
 
+			_sorted_mirror_list_rate=$( printf "${_sorted_mirror_list_rate}" |/usr/bin/sort -k1 -n -r )
+			_sorted_mirror_list=$( printf "${_sorted_mirror_list_rate}" |/usr/bin/awk {'printf $2" "'} )
+			# sorted list "<rate> <mirror>":
+			#echo "${_sorted_mirror_list_rate}"
+
 			[ -n "${win_mirror}" ] && ${ECHO} "${LYELLOW} Winner: ${GREEN}${win_mirror}${NORMAL}"
-			iso_site="${win_mirror} ${iso_site} ${cbsd_iso_mirrors}"
+			iso_site="${_sorted_mirror_list}"
 
 			for i in ${iso_site}; do
 				sha256sum_passed=0


### PR DESCRIPTION
Now we not only find the winner and use it as first mirror,
but also sort the subsequent mirrors as they deteriorate