### PR TITLE
Let freebsd-update determine if install is needed

### DIFF
--- a/tools/baseupdate
+++ b/tools/baseupdate
@@ -37,7 +37,7 @@ update_base()
 	sqlfile="local"
 
 	_sql="SELECT platform,name,arch,targetarch,ver FROM bsdbase"
-	cbsdsql ${sqlfile} ${_sql}| while read _platform _name _arch _targetarch _ver; do
+	cbsdsql ${sqlfile} ${_sql} | while read _platform _name _arch _targetarch _ver; do
 		base="${_name}_${_arch}_${_targetarch}_${_ver}"
 		basepath=${workdir}/base/${base}
 		${ECHO} ${MAGENTA}"Updating ${basepath}"${NORMAL}
@@ -50,8 +50,7 @@ update_base()
 				trap "/bin/rm -f ${update_conf}" HUP INT ABRT BUS TERM EXIT
 				generate_freebsd_config "${updateconf}"
 				FBSD_UPDATE="/usr/sbin/freebsd-update -f ${updateconf} -b ${basepath} --not-running-from-cron"
-				/usr/bin/env PAGER=/bin/cat ${FBSD_UPDATE} fetch
-				${FBSD_UPDATE} install
+				/usr/bin/env PAGER=/bin/cat ${FBSD_UPDATE} fetch install
 				;;
 		esac
 	done


### PR DESCRIPTION
freebsd-update install fails if there's nothing to install, so `cbsd baseupdate` was always exiting with error if there's no update. This way, freebsd-update is smart enough to not run install if fetch didn't get new patches.