### PR TITLE
Feature/hbsd update

### DIFF
--- a/tools/baseupdate
+++ b/tools/baseupdate
@@ -43,7 +43,7 @@ update_base()
 		${ECHO} ${MAGENTA}"Updating ${basepath}"${NORMAL}
 		case "${platform}" in
 			HardenedBSD)
-				/usr/sbin/hbsd-update -r "${basepath}"
+				/usr/sbin/hbsd-update -n -r "${basepath}"
 				;;
 			FreeBSD)
 				updateconf=$( /usr/bin/mktemp )


### PR DESCRIPTION
As jails don't need kernel, -n omits updating it.