### PR TITLE
Define value by 0 if rctl dont have any data

### DIFF
--- a/jailctl/jrctl
+++ b/jailctl/jrctl
@@ -350,7 +350,7 @@ jail_rctl()
 							eval _mydesc="\$${res}_desc"
 							eval _val=\$${res}
 							echo "# HELP jail_${i}_${res} ${_mydesc}"
-							echo "jail_${i}_${res} ${_val}"
+							echo "jail_${i}_${res} ${_val:-0}"
 						done
 					done
 					for i in $( border ); do

--- a/jailctl/jrctl
+++ b/jailctl/jrctl
@@ -319,7 +319,7 @@ jail_rctl()
 						eval _mydesc="\$${res}_desc"
 						eval _val=\$${res}
 						echo "# HELP ${emulator}_${jname}_${res} ${_mydesc}"
-						echo "${emulator}_${jname}_${res} ${_val}"
+						echo "${emulator}_${jname}_${res} ${_val:-0}"
 					done
 				fi
 			else
@@ -365,7 +365,7 @@ jail_rctl()
 							eval _mydesc="\$${res}_desc"
 							eval _val=\$${res}
 							echo "# HELP bhyve_${i}_${res} ${_mydesc}"
-							echo "bhyve_${i}_${res} ${_val}"
+							echo "bhyve_${i}_${res} ${_val:-0}"
 						done
 					done
 				fi


### PR DESCRIPTION
Последняя версия  Prometheus 2.4.3 выводит ошибку: `expected value after metric, got "MNAME"` - это происходит из-за того, что некоторые значения не отдаются rctl и парсинге index.html выводится ошибка и данные не складываются
До патча:
```
# HELP bhyve_test_datasize data size, in bytes or ^m ^g suffix
bhyve_test_datasize 2125824
# HELP bhyve_test_stacksize stack size, in bytes or ^m ^g suffix
bhyve_test_stacksize 0
# HELP bhyve_test_coredumpsize core dump size, in bytes or ^m ^g suffix
bhyve_test_coredumpsize 0
# HELP bhyve_test_memoryuse resident set size, in bytes or ^m ^g suffix
bhyve_test_memoryuse 236089344
# HELP bhyve_test_memorylocked locked memory, in bytes or ^m ^g suffix
bhyve_test_memorylocked 0
# HELP bhyve_test_maxproc number of processes
bhyve_test_maxproc 1
# HELP bhyve_test_openfiles file descriptor table size
bhyve_test_openfiles 0
# HELP bhyve_test_vmemoryuse address space limit, in bytes or ^m ^g suffix
bhyve_test_vmemoryuse 1149112320
# HELP bhyve_test_pseudoterminals number of PTYs
bhyve_test_pseudoterminals 
# HELP bhyve_test_swapuse swap usage, in bytes or ^m ^g suffix
bhyve_test_swapuse 
# HELP bhyve_test_nthr number of threads
bhyve_test_nthr 21
# HELP bhyve_test_msgqqueued number of queued SysV messages
bhyve_test_msgqqueued 
# HELP bhyve_test_msgqsize SysV message queue size, in bytes or ^m ^g suffix
bhyve_test_msgqsize 
# HELP bhyve_test_nmsgq number of SysV message queues
bhyve_test_nmsgq 
# HELP bhyve_test_nsem number of SysV semaphores
bhyve_test_nsem 
# HELP bhyve_test_nsemop number of SysV semaphores modified in a single semop(2) call
bhyve_test_nsemop 0
# HELP bhyve_test_nshm number of SysV shared memory segments
bhyve_test_nshm 
# HELP bhyve_test_shmsize SysV shared memory size, in bytes or ^m ^g suffix
bhyve_test_shmsize 
# HELP bhyve_test_wallclock wallclock time, in seconds
bhyve_test_wallclock 2135
# HELP bhyve_test_pcpu %CPU, in percents of a single CPU core
bhyve_test_pcpu 0
# HELP bhyve_test_readbps filesystem reads, in bytes per second
bhyve_test_readbps 0
# HELP bhyve_test_writebps filesystem writes, in bytes per second
bhyve_test_writebps 0
# HELP bhyve_test_readiops filesystem reads, in operations per second
bhyve_test_readiops 0
# HELP bhyve_test_writeiops filesystem writes, in operations per second
bhyve_test_writeiops 0
```

После:
```
# HELP bhyve_test_datasize data size, in bytes or ^m ^g suffix
bhyve_test_datasize 2125824
# HELP bhyve_test_stacksize stack size, in bytes or ^m ^g suffix
bhyve_test_stacksize 0
# HELP bhyve_test_coredumpsize core dump size, in bytes or ^m ^g suffix
bhyve_test_coredumpsize 0
# HELP bhyve_test_memoryuse resident set size, in bytes or ^m ^g suffix
bhyve_test_memoryuse 235999232
# HELP bhyve_test_memorylocked locked memory, in bytes or ^m ^g suffix
bhyve_test_memorylocked 0
# HELP bhyve_test_maxproc number of processes
bhyve_test_maxproc 1
# HELP bhyve_test_openfiles file descriptor table size
bhyve_test_openfiles 256
# HELP bhyve_test_vmemoryuse address space limit, in bytes or ^m ^g suffix
bhyve_test_vmemoryuse 1134428160
# HELP bhyve_test_pseudoterminals number of PTYs
bhyve_test_pseudoterminals 0
# HELP bhyve_test_swapuse swap usage, in bytes or ^m ^g suffix
bhyve_test_swapuse 0
# HELP bhyve_test_nthr number of threads
bhyve_test_nthr 21
# HELP bhyve_test_msgqqueued number of queued SysV messages
bhyve_test_msgqqueued 0
# HELP bhyve_test_msgqsize SysV message queue size, in bytes or ^m ^g suffix
bhyve_test_msgqsize 0
# HELP bhyve_test_nmsgq number of SysV message queues
bhyve_test_nmsgq 0
# HELP bhyve_test_nsem number of SysV semaphores
bhyve_test_nsem 0
# HELP bhyve_test_nsemop number of SysV semaphores modified in a single semop(2) call
bhyve_test_nsemop 0
# HELP bhyve_test_nshm number of SysV shared memory segments
bhyve_test_nshm 0
# HELP bhyve_test_shmsize SysV shared memory size, in bytes or ^m ^g suffix
bhyve_test_shmsize 0
# HELP bhyve_test_wallclock wallclock time, in seconds
bhyve_test_wallclock 43692
# HELP bhyve_test_pcpu %CPU, in percents of a single CPU core
bhyve_test_pcpu 0
# HELP bhyve_test_readbps filesystem reads, in bytes per second
bhyve_test_readbps 0
# HELP bhyve_test_writebps filesystem writes, in bytes per second
bhyve_test_writebps 0
# HELP bhyve_test_readiops filesystem reads, in operations per second
bhyve_test_readiops 0
# HELP bhyve_test_writeiops filesystem writes, in operations per second
bhyve_test_writeiops 0
```
