### PR TITLE
Search for bridge by group

### DIFF
--- a/bhyve.subr
+++ b/bhyve.subr
@@ -365,7 +365,7 @@ compile_nic_args()
 				get_vm_uplink_interface ${nic_parent}
 				;;
 			*)
-				_is_bridge=$( substr --pos=0 --len=6 --str=${nic_parent} )
+				_is_bridge=$( /sbin/ifconfig ${nic_parent} | /usr/bin/awk '/groups:/{print $2}' | /usr/bin/grep -o bridge )
 				if [ "${_is_bridge}" != "bridge" ]; then
 					# this is not bridge, detect uplink iface
 					get_vm_uplink_interface ${nic_parent}


### PR DESCRIPTION
Solves the problem if already configured device is renamed. Example: `ifconfig_bridge0_name="cbsd"`