### PR TITLE
Fix typo in vm-openbsd-x86-6.conf (64 vs 63)

### DIFF
--- a/etc/defaults/vm-openbsd-x86-6.conf
+++ b/etc/defaults/vm-openbsd-x86-6.conf
@@ -20,7 +20,7 @@ http://mirror.internode.on.net/pub/OpenBSD/6.4/amd64/ \
 # Official CBSD project mirrors
 cbsd_iso_mirrors="http://cbsd.lifec0re.net/iso/ http://electrode.bsdstore.ru/iso/"
 
-iso_img="install63.fs"
+iso_img="install64.fs"
 
 # register_iso as:
 register_iso_name="cbsd-iso-${iso_img}"


### PR DESCRIPTION
Update vm-openbsd-x86-6.conf
Fix a typo on iso_img:
- install63.fs -> install64.fs