### PR TITLE
Enable adduser script to honor UID and GID when present in jconf file

### DIFF
--- a/modules/bsdconf.d/adduser
+++ b/modules/bsdconf.d/adduser
@@ -305,6 +305,8 @@ if [ -r "${fromfile}" ]; then
 		f_getvar user_pw_${i} pw
 		f_getvar user_pw_${i}_crypt epw
 		f_getvar user_gecos_${i} fullname
+		f_getvar user_uid_${i} uid
+		f_getvar user_gid_${i} gid
 		f_getvar user_home_${i} home
 		f_getvar user_shell_${i} shell
 		f_getvar user_member_groups_${i} secgroup


### PR DESCRIPTION
Functionality for setting UID and GID when creating a user in a jail is already there in the adduser script. However it didn't offer it at jail creation when reading parameters from a jconf file. This commit adds the missing functionality.

Limitation: The corresponding lines (i.e. "user_uid_$NAME" and "user_gid_$NAME") have to be added by hand / configuration management at this point. The script adduser-tui was not extended to offer dialogs for setting them.