### PR TITLE
Few improvements

### DIFF
--- a/jailctl/j2slave
+++ b/jailctl/j2slave
@@ -10,7 +10,7 @@ ADDHELP="progress=0,1 show progress, by default 1, yes\n"
 
 sharedfs=0
 tryoffline=0
-progress=1
+progress=0
 
 . ${cbsdinit}
 
@@ -110,7 +110,7 @@ cbsdlogger NOTICE ${CBSD_APP}: rsync ${jname} data, port: 1873, secrets: ${etcdi
 if [ ${progress} -eq 1 ]; then
 	_rs_progress="--progress"
 else
-	_rs_progress="--verbose"
+	_rs_progress=""
 fi
 
 # sync for sysdata

--- a/sudoexec/initenv
+++ b/sudoexec/initenv
@@ -435,6 +435,7 @@ phase3()
 			${ECHO} "${N2_COLOR}${_hname}${N1_COLOR} - Wrong hostname. Full hostname must be not equal short hostname. Please set FQDN (${N2_COLOR}${_hname}.my.domain${N1_COLOR} for example):${N0_COLOR}"
 			if [ "${inter}" = "0" ]; then
 				p="${_hname}.my.domain"
+				_namenotset=0
 			else
 				read p
 			fi

--- a/sudoexec/jstart
+++ b/sudoexec/jstart
@@ -699,9 +699,11 @@ echo ${ST} > ${FID}
 exec_cbsdjail_first_boot
 
 external_exec_script -s start.d
-external_exec_master_script "master_poststart.d"
 
 get_jid
+jid=${myjid}
+external_exec_master_script "master_poststart.d"
+
 
 if [ ${myjid} -gt 0 ]; then
 	status="1"

--- a/tools/fwcounters
+++ b/tools/fwcounters
@@ -66,7 +66,8 @@ insert()
 	fi
 
 	if [ "${mode}" = "remove" ]; then
-		/sbin/ipfw -q delete ${FWIN} ${FWOUT}
+		ipfw -q delete `ipfw show | grep "jail ${jid}" | cut -f 1 -d ' '`
+		#/sbin/ipfw -q delete ${FWIN} ${FWOUT}
 		rm -f "${ftmpdir}/${jname}-fwout" "${ftmpdir}/${jname}-fwin"
 	fi
 }

--- a/tools/fwcounters
+++ b/tools/fwcounters
@@ -66,7 +66,7 @@ insert()
 	fi
 
 	if [ "${mode}" = "remove" ]; then
-		/sbin/ipfw -q delete `/sbin/ipfw show | /usr/bin/grep "jail ${jid}" | /usr/bin/cut -f 1 -d ' '`
+		/sbin/ipfw -q delete `/sbin/ipfw show | /usr/bin/grep "jail ${jid} " | /usr/bin/cut -f 1 -d ' '`
 		#/sbin/ipfw -q delete ${FWIN} ${FWOUT}
 		rm -f "${ftmpdir}/${jname}-fwout" "${ftmpdir}/${jname}-fwin"
 	fi

--- a/tools/fwcounters
+++ b/tools/fwcounters
@@ -66,7 +66,7 @@ insert()
 	fi
 
 	if [ "${mode}" = "remove" ]; then
-		ipfw -q delete `ipfw show | grep "jail ${jid}" | cut -f 1 -d ' '`
+		/sbin/ipfw -q delete `/sbin/ipfw show | /usr/bin/grep "jail ${jid}" | /usr/bin/cut -f 1 -d ' '`
 		#/sbin/ipfw -q delete ${FWIN} ${FWOUT}
 		rm -f "${ftmpdir}/${jname}-fwout" "${ftmpdir}/${jname}-fwin"
 	fi


### PR DESCRIPTION
Makes using master_poststartup.d for automatic ipfw add ... jail ${jid} possible
Also deletes all rules with "jail ${jid}" when the jail gets removes
Fixed loop in initenv-tui with a not FQDN as hostname
Fixed verbose rsync
