### PR TITLE
Add tmux nested mode for bhyve.

### DIFF
--- a/bhyve.subr
+++ b/bhyve.subr
@@ -58,6 +58,7 @@ init_bhyve()
 
 	tmuxcmd=$(which tmux)
 	[ -z "${tmuxcmd}" ] && err 1 "${N1_COLOR}The current version requires ${N2_COLOR}tmux${N1_COLOR}\nPlease run ${N2_COLOR}pkg install tmux ${N1_COLOR} or ${N2_COLOR}make -C /usr/ports/sysutils/tmux install${N1_COLOR} it.${N0_COLOR}"
+	tmuxcmd="${tmuxcmd} -Lcbsd-${jname}"
 }
 
 # return 0 or 1 if $1 bus id exist in global $bhyve_pci_id_busy_list

--- a/bhyve.subr
+++ b/bhyve.subr
@@ -58,7 +58,7 @@ init_bhyve()
 
 	tmuxcmd=$(which tmux)
 	[ -z "${tmuxcmd}" ] && err 1 "${N1_COLOR}The current version requires ${N2_COLOR}tmux${N1_COLOR}\nPlease run ${N2_COLOR}pkg install tmux ${N1_COLOR} or ${N2_COLOR}make -C /usr/ports/sysutils/tmux install${N1_COLOR} it.${N0_COLOR}"
-	tmuxcmd="${tmuxcmd} -Lcbsd-${jname}"
+	tmuxcmd="/usr/local/bin/tmux -Lcbsd-${jname}"
 }
 
 # return 0 or 1 if $1 bus id exist in global $bhyve_pci_id_busy_list

--- a/jailctl/blogin
+++ b/jailctl/blogin
@@ -68,7 +68,7 @@ login_internal()
 	fi
 
 	export TERM=xterm
-	"$(which tmux)" -Lcbsd-"${jname}" attach-session
+	/usr/local/bin/tmux -Lcbsd-"${jname}" attach-session
 }
 
 

--- a/jailctl/blogin
+++ b/jailctl/blogin
@@ -68,7 +68,7 @@ login_internal()
 	fi
 
 	export TERM=xterm
-	/usr/local/bin/tmux attach-session -t cbsdb-${jname} 2>/dev/null || /usr/local/bin/tmux attach-session -t cbsd-${jname}
+	"$(which tmux)" -Lcbsd-"${jname}" attach-session
 }
 
 

--- a/sudoexec/bstart
+++ b/sudoexec/bstart
@@ -573,18 +573,18 @@ EOF
 		gdb|lldb)
 			if [ "${lm}" = "1" ]; then
 				# for live migration always run in tmux due to non-interactive commands from remote side
-				env cbsd_workdir="${workdir}" ${tmuxcmd} -2 -u new -d -s "cbsd-${jname}" "/bin/sh ${sharedir}/bhyverun.sh -c ${jailsysdir}/${jname}/bhyve.conf -g ${debug_engine} ${checkpoint_args}"
+				env cbsd_workdir="${workdir}" ${tmuxcmd} -2 -u new -d "/bin/sh ${sharedir}/bhyverun.sh -c ${jailsysdir}/${jname}/bhyve.conf -g ${debug_engine} ${checkpoint_args}"
 			else
 				env cbsd_workdir="${workdir}" /bin/sh ${sharedir}/bhyverun.sh -c ${jailsysdir}/${jname}/bhyve.conf -g ${debug_engine} ${checkpoint_args}
 			fi
 			;;
 		*)
-			env cbsd_workdir="${workdir}" ${tmuxcmd} -2 -u new -d -s "cbsd-${jname}" "/bin/sh ${sharedir}/bhyverun.sh -c ${jailsysdir}/${jname}/bhyve.conf -e 1 ${checkpoint_args}"
+			env cbsd_workdir="${workdir}" ${tmuxcmd} -2 -u new -d "/bin/sh ${sharedir}/bhyverun.sh -c ${jailsysdir}/${jname}/bhyve.conf -e 1 ${checkpoint_args}"
 			;;
 	esac
 
 	if [ -n "${console_nmdm}" ]; then
-		${tmuxcmd} select-window -t cbsd-${jname}
+		${tmuxcmd} select-window -t 0
 
 		for i in ${console_nmdm}; do
 			${tmuxcmd} new-window -t ${con} "cu -l ${i} -s 9600"
@@ -601,7 +601,7 @@ EOF
 			con=$(( con + 1 ))
 		done
 
-		${tmuxcmd} select-window -t cbsd-${jname}:0
+		${tmuxcmd} select-window -t 0
 	fi
 
 	# CBSD QUEUE

--- a/sudoexec/bstop
+++ b/sudoexec/bstop
@@ -193,6 +193,8 @@ if [ "${_jailed}" != "0" ]; then
 	echo
 fi
 
+"$(which tmux)" -Lcbsd-"${jname}" kill-server
+
 end_time=$( /bin/date +%s )
 cbsdlogger NOTICE ${CBSD_APP}: bhyve domain ${jname} stopped in $(( end_time - st_time ))s
 exit 0

--- a/sudoexec/bstop
+++ b/sudoexec/bstop
@@ -193,7 +193,7 @@ if [ "${_jailed}" != "0" ]; then
 	echo
 fi
 
-"$(which tmux)" -Lcbsd-"${jname}" kill-server
+/usr/local/bin/tmux -Lcbsd-"${jname}" kill-server
 
 end_time=$( /bin/date +%s )
 cbsdlogger NOTICE ${CBSD_APP}: bhyve domain ${jname} stopped in $(( end_time - st_time ))s


### PR DESCRIPTION
Old behavior cbsd not work inside tmux session, with error
"sessions should be nested with care, unset $TMUX to force"

Now bhyve instance make dedicated tmux socket/server.

Default control in nested session, prefix key 'Ctrl+b+b'

Deleted attach `cbsdb-${jname}` exist only in blogin
live migration not tested.