### PR TITLE
Search bridge/epair by group name

### DIFF
--- a/vnet.subr
+++ b/vnet.subr
@@ -25,7 +25,7 @@ init_vnet()
 # return 1 when error
 find_first_freenic()
 {
-	local _i _epair _A 
+	local _i _epair _A
 	local _num=1 # begin from 1, due to 0 often used for system usage ( e.g: virbr0 on Xen )
 
 	[ -z $1 ] && return 1
@@ -145,7 +145,7 @@ get_my_device()
 	_dev=$1
 	_desc=$2
 
-	for _i in $( show_all_nic_by_name ${_dev} ); do
+	for _i in $( ${IFCONFIG_CMD} -g ${_dev} ); do
 		_uplink=$( get_device_uplink ${_i} ${_desc} )
 		[ "${_uplink}" = "${_desc}" ] && echo "${_i}" && return 0
 	done


### PR DESCRIPTION
As `get_my_device()` is called with `bridge` or `epair` as first argument, which are also interface group names, `ifconfig -g bridge` can be used. It fixes a bug on systems where bridge interface for CBSD is already configured but it's name is changed like so:
```
ifconfig_bridge0_name="cbsd0"
ifconfig_cbsd0="inet 172.16.0.254 netmask 255.255.255.0 description lagg0"
```