### PR TITLE
Feature/vnet dhcp

### DIFF
--- a/settings-tui-jail.subr
+++ b/settings-tui-jail.subr
@@ -56,6 +56,7 @@ ip4_addr_msg="Jail IPv4 and/or IPv6 address. Current CBSD IPv4 pool: ${nodeippoo
  Use IP/PREFIX form, comma-separated for aliases.\n\
  '0' to disable IP creating by CBSD (useful for vnet jails)\n\
  'DHCP' for determine free IPv4 automatically\n\
+ 'REALDHCP' when DHCP server is used (uses dhclient - useful for vnet jails)\n\
  'nic1#ip_addr,nic2#ip_addr' for multiple NIC form\n"
 
 GET_JAILPROFILE_MSG="Profile for jcreate"
@@ -753,7 +754,7 @@ get_construct_gw4()
 
 	f_dialog_input _input "${GET_GW4_MSG}" "${gw4}" \
 			"${_message}" || return $?
-	
+
 	gw4="${_input}"
 }
 

--- a/sudoexec/jstart
+++ b/sudoexec/jstart
@@ -648,7 +648,7 @@ trap "" HUP INT ABRT BUS TERM EXIT
 
 ### late start ###
 # late exec_start: for zfsattached and vnet-based jails
-# this is necessary for any operations that must be performed after 
+# this is necessary for any operations that must be performed after
 # creating the jail but before running real exec_start
 late_start=
 
@@ -680,6 +680,9 @@ if [ ${vnet} -eq 1 ]; then
 		# make lock
 		echo "${jname}" > ${tmpdir}/eth${eth_seq}.locked
 		${IFCONFIG_CMD} ${i} name eth${eth_seq} && ${IFCONFIG_CMD} eth${eth_seq} vnet ${jname}
+		if [ "${ip4_addr}" = "REALDHCP" ]; then
+			/usr/sbin/jexec ${jname} /sbin/dhclient eth${eth_seq}
+		fi
 		# release lock
 		/bin/rm -f ${tmpdir}/eth${eth_seq}.locked
 		eth_seq=$(( eth_seq + 1 ))


### PR DESCRIPTION
~depends on #445~

For now this is incomplete PR, but I wanted us to have a place to discuss the code. The idea is to make CBSD able to use DHCP server through epair->bridge. As `DHCP` is reserved word, I decided to use `REALDHCP` as special keyword which runs `dhclient` on epair interface(s).

Missing:

- ~option in `jconstruct-tui`~
- ~[documentation](https://github.com/cbsd/cbsd.io/pull/11)~