### PR TITLE
Replaced hardcoded max. for vm_cpus

### DIFF
--- a/settings-tui-virtual.subr
+++ b/settings-tui-virtual.subr
@@ -9,7 +9,7 @@ ip4_addr_msg="VM IPv4 and/or IPv6 address. Current CBSD IPv4 pool: ${nodeippool}
 
 GET_CD_BOOT_FIRMWARE_MSG="Choose CD boot firmware"
 GET_CONSOLE_MSG="Choose default console"
-GET_CPUS_MSG="Number of CPUs: 1, max: 16"
+GET_CPUS_MSG="Number of CPUs: 1, max: ${vm_cpus_max}"
 GET_EFI_MSG="Choose UEFI firmware"
 GET_GUESTFS_MSG="Choose FS for boot image"
 GET_GW4_MSG="Enter default gateway inside VMs or jail"
@@ -162,12 +162,12 @@ get_construct_vm_cpus()
 			continue
 		fi
 
-		if [ ${_input} -gt ${ncpu} -a ${_input} -lt 16 ]; then
+		if [ ${_input} -gt ${ncpu} -a ${_input} -lt ${vm_cpus_max} ]; then
 			if ! getyesno "Warning! Current node cpu: ${ncpu}. Overcommitting vCPUs can hurt perfomance.\nContinue anyway?"; then
 				continue
 			fi
-		elif [ ${_input} -lt 1 -o ${_input} -gt 16 ]; then
-			f_show_msg "Valid number of guest CPUs within 1 - 16 range"
+		elif [ ${_input} -lt 1 -o ${_input} -gt ${vm_cpus_max} ]; then
+			f_show_msg "Valid number of guest CPUs within 1 - ${vm_cpus_max} range"
 			continue
 		fi
 		_ret=0

--- a/sudoexec/bstart
+++ b/sudoexec/bstart
@@ -875,10 +875,10 @@ bcleanup jname="${jname}"
 [ -z "${iso_auto_fetch}" ] && iso_auto_fetch=0
 [ -z "${debug}" ] && debug=0
 
-if [ ${vm_cpus} -gt ${ncpu} -a ${vm_cpus} -lt 16 ]; then
+if [ ${vm_cpus} -gt ${ncpu} -a ${vm_cpus} -lt ${vm_cpus_max} ]; then
 	${ECHO} "${N1_COLOR}Warning! Current node cpu: ${N2_COLOR}${ncpu}${N1_COLOR}, guest cpu: ${N2_COLOR}${vm_cpus}. ${N1_COLOR}Overcommitting vCPUs can hurt perfomance.${N0_COLOR}"
-elif [ ${vm_cpus} -lt 1 -o ${vm_cpus} -gt 16 ]; then
-	err 1 "${N1_COLOR}Valid number of guest CPUs within 1 - 16 range. Current vm_cpus: ${N2_COLOR}${vm_cpus}${N0_COLOR}"
+elif [ ${vm_cpus} -lt 1 -o ${vm_cpus} -gt ${vm_cpus_max} ]; then
+	err 1 "${N1_COLOR}Valid number of guest CPUs within 1 - ${vm_cpus_max} range. Current vm_cpus: ${N2_COLOR}${vm_cpus}${N0_COLOR}"
 fi
 
 # hardcoded first disk path from SQL. Todo: mark bootable disk(s)

--- a/sudoexec/xstart
+++ b/sudoexec/xstart
@@ -549,10 +549,10 @@ readconf ${default_profile}
 [ -z "${iso_auto_fetch}" ] && iso_auto_fetch=0
 [ -z "${debug}" ] && debug=0
 
-if [ ${vm_cpus} -gt ${ncpu} -a ${vm_cpus} -lt 16 ]; then
+if [ ${vm_cpus} -gt ${ncpu} -a ${vm_cpus} -lt ${vm_cpus_max} ]; then
 	${ECHO} "${N1_COLOR}Warning! Current node cpu: ${N2_COLOR}${ncpu}${N1_COLOR}, guest cpu: ${N2_COLOR}${vm_cpus}. ${N1_COLOR}Overcommitting vCPUs can hurt perfomance.${N0_COLOR}"
-elif [ ${vm_cpus} -lt 1 -o ${vm_cpus} -gt 16 ]; then
-	err 1 "${N1_COLOR}Valid number of guest CPUs within 1 - 16 range. Current vm_cpus: ${N2_COLOR}${vm_cpus}${N0_COLOR}"
+elif [ ${vm_cpus} -lt 1 -o ${vm_cpus} -gt ${vm_cpus_max} ]; then
+	err 1 "${N1_COLOR}Valid number of guest CPUs within 1 - ${vm_cpus_max} range. Current vm_cpus: ${N2_COLOR}${vm_cpus}${N0_COLOR}"
 fi
 
 main_sqlite_local="${jailsysdir}/${jname}/local.sqlite"


### PR DESCRIPTION
Changes to enable that vm_cpus_max is used throughout the code instead of the hardcoded value of 16. 

I have tested it on FreeBSD 12.1 and it worked for me. 