### PR TITLE
added label 'name' for prometheus metrics

### DIFF
--- a/jailctl/jrctl
+++ b/jailctl/jrctl
@@ -348,8 +348,8 @@ jail_rctl()
 					for res in ${RCTL}; do
 						eval _mydesc="\$${res}_desc"
 						eval _val=\$${res}
-						echo "# HELP ${emulator}_${jname}_${res} ${_mydesc}"
-						echo "${emulator}_${jname}_${res} ${_val:-0}"
+						echo "# HELP ${emulator}_${res} ${_mydesc}"
+						echo "${emulator}_${res}{name=\"${jname}\"} ${_val:-0}"
 					done
 				fi
 			else
@@ -379,8 +379,8 @@ jail_rctl()
 						for res in ${RCTL}; do
 							eval _mydesc="\$${res}_desc"
 							eval _val=\$${res}
-							echo "# HELP jail_${i}_${res} ${_mydesc}"
-							echo "jail_${i}_${res} ${_val:-0}"
+							echo "# HELP jail_${res} ${_mydesc}"
+						  echo "jail_${res}{name=\"${i}\"} ${_val:-0}"
 						done
 					done
 					for i in $( border ); do
@@ -394,8 +394,8 @@ jail_rctl()
 						for res in ${RCTL}; do
 							eval _mydesc="\$${res}_desc"
 							eval _val=\$${res}
-							echo "# HELP bhyve_${i}_${res} ${_mydesc}"
-							echo "bhyve_${i}_${res} ${_val:-0}"
+							echo "# HELP bhyve_${res} ${_mydesc}"
+							echo "bhyve_${res}{name=\"${i}\"} ${_val:-0}"
 						done
 					done
 				fi


### PR DESCRIPTION
This PR adds the jail/vm name as label rather than having it as part of the metric name. I believe this follows the idea of how metrics should be named and labeled in Prometheus a bit closer than now.