### PR TITLE
fixed jstop script to work correctly with jails on bridges

### DIFF
--- a/sudoexec/jstop
+++ b/sudoexec/jstop
@@ -237,7 +237,7 @@ sleep 2
 external_exec_script -s stop.d
 if [ ${vnet} -eq 1 ]; then
 	if [ "${ip4_addr}" = "REALDHCP" ]; then
-		${JEXEC_CMD} ${jname} /bin/pkill -9 dhclient dhcpcd 2>/dev/null 1>&2		# need $emulator support. exec via CBSD jexec instead:
+		#${JEXEC_CMD} ${jname} /bin/pkill -9 dhclient dhcpcd 2>/dev/null 1>&2		# need $emulator support. exec via CBSD jexec instead:
 		jexec jname=${jname} pkill -9 dhclient dhcpcd 2>/dev/null 1>&2
 	fi
 fi
@@ -293,7 +293,7 @@ for pureip in ${IPS}; do
 	[ -n "${VHID}" ] && continue
 	_inet=$?
 	if [ -n "${interface}" -a "${interface}" != "0" ]; then
-		iface=$( getnics-by-ip ip=${pureip} skip=bridge )
+		iface=$( getnics-by-ip ip=${pureip} )
 		ipwmask ${pureip}
 		if [ -n "${IWM}" ]; then
 			case ${_inet} in

--- a/tools/makejconf
+++ b/tools/makejconf
@@ -76,7 +76,7 @@ if [ ${is_special} -eq 0 ]; then
 	if [ "${interface}" = "auto" ]; then
 		geniplist ${ip4_addr}
 		for pureip in ${IPS}; do
-			iface=$( getnics-by-ip ip=${pureip} skip=bridge )
+			iface=$( getnics-by-ip ip=${pureip} )
 			ipwmask ${pureip}
 			if [ -n "${iface}" ]; then
 				[ ${quiet} -ne 1 ] && ${ECHO} "${N1_COLOR}Default NIC automatically selected: ${N2_COLOR}${iface}${N0_COLOR}"


### PR DESCRIPTION
Do not exclude bridge interface on jstop. (also effects tools/makejconf)

fixed a missing comment in the jstop script.