### PR TITLE
Add RISCV64 support

### DIFF
--- a/etc/defaults/buildworld.conf
+++ b/etc/defaults/buildworld.conf
@@ -2,8 +2,8 @@ CBSDRCPT="root@localhost"
 TAILSTRING="30"
 
 # x86_64 - amd64 on dfly platform
-SUPPORTED_ARCH="i386 amd64 arm mips bhyve x86_64 arm64 powerpc"
-SUPPORTED_TARGET="i386 amd64 arm arm64 mips64 bhyve x86_64 aarch64 powerpc64"
+SUPPORTED_ARCH="i386 amd64 arm mips bhyve x86_64 arm64 powerpc riscv"
+SUPPORTED_TARGET="i386 amd64 arm arm64 mips64 bhyve x86_64 aarch64 powerpc64 riscv64"
 
 # default pri for build process
 NICE="20"

--- a/jailctl/jls
+++ b/jailctl/jls
@@ -190,7 +190,7 @@ show_jaildata_from_sql()
 		sqlfile="local"
 	fi
 
-	cbsdsqlro ${sqlfile} SELECT jname FROM jails WHERE emulator=\"jail\" OR emulator=\"qemu-arm-static\" OR emulator=\"qemu-mips64-static\" OR emulator=\"qemu-aarch64-static\" OR emulator=\"qemu-ppc64-static\" ORDER BY jname ${order} | while read jname; do
+	cbsdsqlro ${sqlfile} SELECT jname FROM jails WHERE emulator=\"jail\" OR emulator=\"qemu-arm-static\" OR emulator=\"qemu-mips64-static\" OR emulator=\"qemu-aarch64-static\" OR emulator=\"qemu-ppc64-static\" OR emulator=\"qemu-riscv64-static\" ORDER BY jname ${order} | while read jname; do
 		_status=""
 		. ${jrcconf}
 

--- a/rcconf.subr
+++ b/rcconf.subr
@@ -164,6 +164,11 @@ init_rcconf()
 			arch="powerpc"
 			target_arch="powerpc64"
 			;;
+		qemu-riscv64-static)
+			local source_emulator="${emulator}"
+			arch="riscv"
+			target_arch="riscv64"
+			;;
 	esac
 
 	#skip for not my emulator

--- a/settings-tui-jail.subr
+++ b/settings-tui-jail.subr
@@ -427,6 +427,7 @@ get_construct_arch()
 	local qemu_arm=$( which qemu-arm-static 2>/dev/null )
 	local qemu_aarch64=$( which qemu-aarch64-static 2>/dev/null )
 	local qemu_ppc64=$( which qemu-ppc64-static 2>/dev/null )
+	local qemu_riscv64=$( which qemu-riscv64-static 2>/dev/null )
 
 	local amd64_menu=
 	local i386_menu=
@@ -435,20 +436,26 @@ get_construct_arch()
 
 	local arm_menu=
 	local mips_menu=
+	local riscv_menu=
+
 	local arm_desc=
 	local mips_desc=
+	local riscv_desc=
 
 	local qemu_mips64_desc=
 	local qemu_arm_desc=
 	local qemu_aarch64_desc=
+	local qemu_riscv64_desc=
 
 	local qemu_mips64_enable=
 	local qemu_arm_enable=
 	local qemu_aarch64_enable=
+	local qemu_riscv64_enable=
 
 	local qemu_mips64_menu="MIPS64"
 	local qemu_arm_menu="ARMv6"
 	local qemu_aarch64_menu="ARMv8"
+	local qemu_riscv64_menu="RISCV64"
 
 	local qemu_powerpc64_enable=
 	local qemu_powerpc64_menu="powerpc64"
@@ -513,6 +520,21 @@ get_construct_arch()
 		qemu_powerpc64_desc="You have no qemu-user: please install qemu-devel with BSD_USER and STATIC ops ( emulators/qemu-user-static )"
 	fi
 
+	# test for qemu_riscv64
+	if [ -n "${qemu_riscv64}" ]; then
+		_res=$( 2>&1 ${LDD_CMD} ${qemu_riscv64} | ${GREP_CMD} -q "not a dynamic ELF executable" )
+		if [ $? -eq 0 ]; then
+			qemu_riscv64_enable=1
+			qemu_riscv64_desc="RISCV64 via ${qemu_riscv64}"
+		else
+			qemu_RISCV64_enable=0
+			qemu_RISCV64_desc="${qemu_RISCV64} is not static. Please rebuild with STATIC ( emulators/qemu-user-static )"
+		fi
+	else
+		qemu_RISCV64_enable=0
+		qemu_RISCV64_desc="You have no qemu-user: please install qemu-devel with BSD_USER and STATIC ops ( emulators/qemu-user-static )"
+	fi
+
 	case "${hostarch}" in
 		"amd64")
 			amd64_menu="*"
@@ -537,6 +559,10 @@ get_construct_arch()
 		"ppc64")
 			ppc64_menu="*"
 			ppc64_desc="This is native architecture for this node"
+			;;
+		"riscv")
+			riscv_menu="*"
+			riscv_desc="This is native architecture for this node"
 			;;
 	esac
 
@@ -572,6 +598,11 @@ get_construct_arch()
 			'powerpc'	'ppc64 ${ppc64_menu}'		'POWERPC64 architecture. ${ppc64_desc}'
 			" # END-QUOTE
 			;;
+		riscv64)
+			local menu_list="
+			'riscv'	'riscv ${riscv_menu}'		'RISCV architecture. ${riscv_desc}'
+			" # END-QUOTE
+			;;
 		*)
 			local menu_list="
 			'amd64'	'x86-64 ${amd64_menu}'		'64 bit architecture. ${amd64_desc}'
@@ -604,6 +635,11 @@ get_construct_arch()
 		menu_list="${menu_list} ''	'ppc64 unsupported'	'${qemu_powerpc64_desc}'"
 	fi
 
+	if [ ${qemu_riscv64_enable} -eq 1 ]; then
+		menu_list="${menu_list} 'riscv'	'${qemu_riscv64_menu}'	'${qemu_riscv64_desc}'"
+	else
+		menu_list="${menu_list} ''	'riscv64 unsupported'	'${qemu_riscv64_desc}'"
+	fi
 	cbsd_menubox
 	retval=$?
 

--- a/settings-tui.subr
+++ b/settings-tui.subr
@@ -3,7 +3,7 @@ if [ ! "$_CBSD_SETTINGS_TUI_SUBR" ]; then
 _CBSD_SETTINGS_TUI_SUBR=1
 ###
 
-#required for . ${dialog} 
+#required for . ${dialog}
 TMPFILE="${ftmpdir}/inputbox.$$"
 
 # load emulator-specific function
@@ -880,7 +880,7 @@ EOF
 			jcreate jconf=${TMPFILE} delpkglist=${delpkglist} removejconf=${removejconf}
 			[ $? -ne 0 ] && err 0 "${N1_COLOR}Config file for jconf: ${N2_COLOR}${TMPFILE}${N0_COLOR}"
 			;;
-		qemu-arm-static|qemu-mips64-static|qemu-aarch64-static|qemu-ppc64-static)
+		qemu-arm-static|qemu-mips64-static|qemu-aarch64-static|qemu-ppc64-static|qemu-riscv64-static)
 			make_emulator_part
 			echo "emulator=\"${emulator}\"" >> ${TMPFILE}
 			getyesno "Do you want to create jail immediately?"

--- a/sudoexec/jcreate
+++ b/sudoexec/jcreate
@@ -240,6 +240,9 @@ case "${emulator}" in
 		arch="powerpc"
 		target_arch="powerpc64"
 		;;
+	qemu-riscv64-static)
+		arch="riscv"
+		target_arch="riscv64"
 esac
 
 get_base -v ${ver} ${_basename_args}

--- a/universe.subr
+++ b/universe.subr
@@ -188,6 +188,12 @@ init_target_arch()
 				BUILDPATH="powerpc64-bsd-user"
 				emulator="qemu-ppc64-static"
 			;;
+			"riscv")
+				TARGET="riscv"
+				TARGET_ARCH="riscv64"
+				BUILDPATH="riscv64-bsd-user"
+				emulator="qemu-riscv64-static"
+			;;
 		esac
 	fi
 


### PR DESCRIPTION
This PR adds riscv64 support. It's mainly a copy/paste from mips64

![image](https://user-images.githubusercontent.com/7521540/98446504-22b5b000-211e-11eb-8ae0-b4650ab836f3.png)

more information about riscv on FreeBSD : https://wiki.freebsd.org/riscv
