### PR TITLE
Fix variable of qemu in tui information

### DIFF
--- a/settings-tui-jail.subr
+++ b/settings-tui-jail.subr
@@ -488,7 +488,7 @@ get_construct_arch()
 		_res=$( 2>&1 ${LDD_CMD} ${qemu_aarch64} | ${GREP_CMD} -q "not a dynamic ELF executable" )
 		if [ $? -eq 0 ]; then
 			qemu_aarch64_enable=1
-			qemu_aarch64_desc="aarch64 aka ARMv8 and arm-64 via ${qemu_arm}"
+			qemu_aarch64_desc="aarch64 aka ARMv8 and arm-64 via ${qemu_aarch64}"
 		else
 			qemu_aarch64_enable=0
 			qemu_aarch64_desc="${qemu_aarch64} is not static. Please rebuild with STATIC ( emulators/qemu-user-static )"
@@ -503,7 +503,7 @@ get_construct_arch()
 		_res=$( 2>&1 ${LDD_CMD} ${qemu_ppc64} | ${GREP_CMD} -q "not a dynamic ELF executable" )
 		if [ $? -eq 0 ]; then
 			qemu_powerpc64_enable=1
-			qemu_powerpc64_desc="POWERC64 via ${qemu_arm}"
+			qemu_powerpc64_desc="POWERC64 via ${qemu_ppc64}"
 		else
 			qemu_powerpc64_enable=0
 			qemu_powerpc64_desc="${qemu_ppc64} is not static. Please rebuild with STATIC ( emulators/qemu-user-static )"


### PR DESCRIPTION
${qemu_arm} is used for aarch64 and ppc64 instead of ${qemu_aarch64} and ${qemu_ppc64}.