### PR TITLE
Add command to print emulator of an instance

### DIFF
--- a/jailctl/emulator
+++ b/jailctl/emulator
@@ -1,0 +1,19 @@
+#!/usr/local/bin/cbsd
+#v19.1.9
+CBSDMODULE="jail"
+MYARG=""
+MYOPTARG=""
+MYDESC="Print hypervisor/emulator"
+
+. ${subr}
+
+jname=$1
+[ -z "${jname}" ] && err 1 "${N1_COLOR}No jail specified${N0_COLOR}"
+
+emulator=$(cbsdsqlro local SELECT emulator FROM jails WHERE jname=\"${jname}\")
+if [ ! -z "${emulator}" ]; then
+    echo "${emulator}"
+    exit 0
+fi
+
+err 1 "${N1_COLOR}No such instance${N0_COLOR}"


### PR DESCRIPTION
Use case is simple: Should scripts (external to CBSD) run `bstart` or `jstart` if only data they have is the name?