### PR TITLE
bcreate: do not remove jconf by default

### DIFF
--- a/sudoexec/bcreate
+++ b/sudoexec/bcreate
@@ -88,7 +88,7 @@ done
 if [ -z "${jconf}" ]; then
 	jconf=$( ${MKTEMP_CMD} )
 	export CBSD_INIT_SAVE2FILE=${jconf}		# save args and generate jconf
-	[ -z "${removejconf}" ] && removejconf="1"
+	[ -z "${removejconf}" ] && removejconf="0"  # do not delete jconf by default
 	${SYSRC_CMD} -qf ${jconf} removejconf="${removejconf}" >/dev/null 2>&1
 	. ${cbsdinit}
 	unset CBSD_INIT_SAVE2FILE


### PR DESCRIPTION
Fixes https://github.com/cbsd/cbsd/issues/609
