### PR TITLE
initenv: improve spelling

### DIFF
--- a/sudoexec/initenv
+++ b/sudoexec/initenv
@@ -477,7 +477,7 @@ EOF
 
 	# 10_cbsd_sudoers for compatible with puppet sudo module
 	if [ ! -f "/usr/local/etc/sudoers.d/cbsd_sudoers" -a ! -f "/usr/local/etc/sudoers.d/10_cbsd_sudoers" ]; then
-		if getyesno "Shall i add cbsd user into /usr/local/etc/sudoers.d/cbsd_sudoers sudo file to obtain root privileges for the most cbsd commands?" ${initenv_modify_sudoers}; then
+		if getyesno "Shall I add the cbsd user into /usr/local/etc/sudoers.d/cbsd_sudoers sudo file to obtain root privileges for most of the cbsd commands?" ${initenv_modify_sudoers}; then
 			initenv_modify_sudoers=1
 			[ ! -d /usr/local/etc/sudoers.d ] && /bin/mkdir -p /usr/local/etc/sudoers.d
 			installne "-o root -g wheel -m 440" ${etcdir}/cbsd_sudoers /usr/local/etc/sudoers.d/cbsd_sudoers


### PR DESCRIPTION
Just some minor cosmetic improvements to `sudoexec/initenv`.