### PR TITLE
Update vm-linux-opensuse-leap-15-x86.conf

### DIFF
--- a/etc/defaults/vm-linux-opensuse-leap-15-x86.conf
+++ b/etc/defaults/vm-linux-opensuse-leap-15-x86.conf
@@ -20,6 +20,7 @@ http://mirror.lzu.edu.cn/opensuse/distribution/leap/15.4/iso/ \
 http://www.mirrorservice.org/sites/download.opensuse.org/distribution/leap/15.4/iso/ \
 http://mirror.cedia.org.ec/opensuse/distribution/leap/15.4/iso/ \
 http://opensuse.hro.nl/opensuse/distribution/leap/15.4/iso/ \
+https://download.opensuse.org/distribution/leap/15.4/iso/ \
 "
 
 # Official CBSD project mirrors
@@ -30,7 +31,7 @@ http://opensuse.hro.nl/opensuse/distribution/leap/15.4/iso/ \
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
 cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/"
 
-iso_img="openSUSE-Leap-15.4-DVD-x86_64-Current.iso"
+iso_img="openSUSE-Leap-15.4-DVD-x86_64-Build243.2-Media.iso"
 
 # register_iso as:
 register_iso_name="cbsd-iso-${iso_img}"


### PR DESCRIPTION
There is no Current image in mirror sites but a Build...-Media one.

BTW, I added the standard download.opensuse sites (which have Current iso file ...)