### PR TITLE
Mounting via fstab.local, with escaped space in path.

### DIFF
--- a/subr/system.subr
+++ b/subr/system.subr
@@ -14,7 +14,7 @@ is_mounted()
 
 	# test for destrination is directory ?
 	if [ -d "${1}" ]; then
-		_tst=$( ${DF_CMD} ${1} | ${TAIL_CMD} +2 | ${AWK_CMD} '{ print $6 }' )
+		_tst=$( ${DF_CMD} "${1}" | ${TAIL_CMD} +2 | ${AWK_CMD} '{ print $6 }' )
 		[ "${_tst}" = "${1}" ] && return 0
 	else
 		# is ZFS?

--- a/tools/mountfstab
+++ b/tools/mountfstab
@@ -168,7 +168,7 @@ ${CAT_CMD} ${fstab} | while read _device _mountpt _fs _mode _a _b; do
 	fi
 
 	mnt=0
-	prefix=$( substr --pos=0 --len=1 --str=${_device} )
+	prefix=$( substr --pos=0 --len=1 "--str=${_device}" )
 
 	if [ "${_fs}" = "geli" ]; then
 		# prepare src part
@@ -194,7 +194,7 @@ ${CAT_CMD} ${fstab} | while read _device _mountpt _fs _mode _a _b; do
 		if [ "${prefix}" != "/" ]; then
 			_device="${workdir}/${_device}"
 		else
-			if ! [ -d ${_device} -o -c ${_device} -o -b ${_device} ]; then
+			if ! [ -d "${_device}" -o -c "${_device}" -o -b "${_device}" ]; then
 				${ECHO} "${W1_COLOR}${CBSD_APP} warning: ${N1_COLOR}mountfstab: no such source directory for jail ${jname}: ${N2_COLOR}${_device}${N0_COLOR}"
 				continue
 			fi
@@ -221,7 +221,7 @@ ${CAT_CMD} ${fstab} | while read _device _mountpt _fs _mode _a _b; do
 		fi
 	fi
 
-	${MOUNT_CMD} -t ${_fs} -o${_mode} ${_device} ${jroot}${_mountpt}
+	${MOUNT_CMD} -t ${_fs} -o${_mode} "${_device}" "${jroot}${_mountpt}"
 done
 
 exit 0


### PR DESCRIPTION
Patches for mounting via fstab.local, with escaped space in path.
For example, 
/mnt/pool/with\ space	/var/opt/with\ space	nullfs	ro	0	0

Because space escaped as octal (\040) doesn't work.