### PR TITLE
Rewrite umount_cdirs() to hanle paths with spaces

### DIFF
--- a/subr/system.subr
+++ b/subr/system.subr
@@ -381,23 +381,28 @@ unmountbase()
 # if exist $2 - do not unmount root of $1
 umount_cdirs()
 {
-	local _unmount_root=1 _mount_list _mpath _mount_point
-	[ -n "${1}" ] && path="$1"
-	[ -n "${2}" ] && _unmount_root=0
+       local _unmount_root=1 _mount_point _tmpfile
+        [ -n "${1}" ] && path="$1"
+        [ -n "${2}" ] && _unmount_root=0
 
-	# when error before path, we do not have any mounts by scripts
-	[ -z "${path}" ] && return 0
+        # when error before path, we do not have any mounts by scripts
+        [ -z "${path}" ] && return 0
 
-	_mount_list=$( ${MOUNT_CMD} | ${SORT_CMD} -r | ${AWK_CMD} -F" on " '{print $2}' )
+        _tmpfile=$( ${MKTEMP_CMD} )
 
-	_mpath=
-	for _mount_point in ${_mount_list}; do
-		case ${_mount_point} in
-			${path}/*)
-				[ -n "${_mount_point}" ] && _mpath="${_mpath} ${path}${_mount_point#$path}"
-				;;
-		esac
-	done
+        # this one will work on path with " (" in it because of greedy sed regexp,
+        # for example "/mnt/backup (1) on /jails/jail1/backup (1) (nullfs, local, read-only)"
+        ${MOUNT_CMD} | ${SORT_CMD} -r | ${SED_CMD} -E 's/(.*) on \/(.*) \((.*)/\/\2/'' > "$_tmpfile"
+
+        ${CAT_CMD} "$_tmpfile" | while read _mount_point; do
+                case ${_mount_point} in
+                        ${path}/*)
+                                [ -n "${_mount_point}" ] && ${UMOUNT_CMD} -f "${_mount_point}"
+                                ;;
+                esac
+        done
+
+        ${RM_CMD} -f "$_tmpfile"
 
 	[ -n "${_mpath}" ] && ${UMOUNT_CMD} -f ${_mpath}
 	#finaly unmount cdir

--- a/subr/system.subr
+++ b/subr/system.subr
@@ -381,7 +381,7 @@ unmountbase()
 # if exist $2 - do not unmount root of $1
 umount_cdirs()
 {
-       local _unmount_root=1 _mount_point _tmpfile
+        local _unmount_root=1 _mount_point _tmpfile
         [ -n "${1}" ] && path="$1"
         [ -n "${2}" ] && _unmount_root=0
 


### PR DESCRIPTION
One more piece of handling spaces in path.
Using _sed_ instead _awk_ to split _mount_ output and take dest path between ' on /' and last ' ('