### PR TITLE
ability for jset assign IP to particular interface

### DIFF
--- a/jailctl/jset
+++ b/jailctl/jset
@@ -351,7 +351,20 @@ modify_ipaddr()
 			# not necessary due to netif/routing restart?
 			#jexec jname=${jname} ${IFCONFIG_CMD} ${_iface} ${_MODIF} ${_pureip} alias
 		else
-			${IFCONFIG_CMD} ${_iface} ${_MODIF} ${_pureip} alias
+			_ip_test=`echo ${_pureip} | egrep '[0-9]#[0-9]' | wc -l`
+			if [ ${_ip_test} -eq 1 ]; then
+				ip_interface=`echo ${_pureip} | cut -d '#' -f 1`
+				if [ -z ${ip_interface} ]; then
+					ip_interface=${_iface}
+				fi
+				ip_addr=`echo ${_pureip} | cut -d '#' -f 2`
+				if [ -z ${ip_addr} ]; then
+					ip_addr=${_pureip}
+				fi
+				${IFCONFIG_CMD} ${ip_interface} ${_MODIF} ${ip_addr} alias
+			else
+				${IFCONFIG_CMD} ${_iface} ${_MODIF} ${_pureip} alias
+			fi
 		fi
 		IFS=","
 	done
@@ -364,6 +377,7 @@ modify_ipaddr()
 	fi
 
 	#construct ipX.addr string
+	_IP4=`echo ${_IP4} | perl -ne 'chomp;@a=map {$_ =~ /#/ ? ~/#(.+)$/ : $_;$1 || $_} split /,/,$_;print join ",",@a;'`
 	_nIPs="ip4.addr=${_IP4} ip6.addr=${_IP6}"
 
 	cbsdlogger NOTICE ${CBSD_APP}: modify_ipaddr: ${JAIL_CMD} -m ${_nIPs} jid=${jid}

--- a/jailctl/jset
+++ b/jailctl/jset
@@ -223,7 +223,20 @@ modify_ipaddr()
 			if [ ${vnet} -eq 1 ]; then
 				jexec jname=${jname} ${IFCONFIG_CMD} ${_iface} ${_MODIF} ${IWM} -alias >/dev/null 2>/dev/null
 			else
+                _ip_test=`echo ${IWM} | egrep '[0-9]#[0-9]' | wc -l`
+                if [ ${_ip_test} -eq 1 ]; then
+                    ip_interface=`echo ${IWM} | cut -d '#' -f 1`
+                    if [ -z ${ip_interface} ]; then
+                        ip_interface=${_iface}
+                    fi
+                    ip_addr=`echo ${IWM} | cut -d '#' -f 2`
+                    if [ -z ${ip_addr} ]; then
+                        ip_addr=${IWM}
+                    fi
+				${IFCONFIG_CMD} ${ip_interface} ${_MODIF} ${ip_addr} -alias >/dev/null 2>/dev/null
+			else
 				${IFCONFIG_CMD} ${_iface} ${_MODIF} ${IWM} -alias >/dev/null 2>/dev/null
+			fi
 			fi
 			IFS=","
 		fi


### PR DESCRIPTION
This code gave to jset ability set IP for a particular interface
for example, now we can choose an interface for each IP
```
cbsd jset interface=bridge0 ip4_addr="bridge0#192.168.200.32,lo0#172.16.29.3" jname=service_test
```