### PR TITLE
Fix wrong path comment in color{,-white}.conf

### DIFF
--- a/etc/defaults/color-white.conf
+++ b/etc/defaults/color-white.conf
@@ -1,7 +1,7 @@
 # custom color sample.
 # Put this file into ~cbsd/etc/ directory.
 # See original schema and ansii color defines in
-#  /usr/local/cbsd/ansiicolor.subr
+#  /usr/local/cbsd/subr/ansiicolor.subr
 N0_COLOR="${NORMAL}"			# disable color
 N1_COLOR="${BLACK}"			# normal default CBSD text color
 N2_COLOR="${BLACK}"			# normal second CBSD color

--- a/etc/defaults/color.conf
+++ b/etc/defaults/color.conf
@@ -2,7 +2,7 @@
 # for white schema see color-white.conf sample
 # Put this file into ~cbsd/etc/ directory.
 # See original schema and ansii color defines in
-#  /usr/local/cbsd/ansiicolor.subr
+#  /usr/local/cbsd/subr/ansiicolor.subr
 N0_COLOR="${NORMAL}"			# disable color
 N1_COLOR="${GRAY}"			# normal default CBSD text color
 N2_COLOR="${CYAN}"			# normal second CBSD color


### PR DESCRIPTION
Noticed a small piece of incorrect info while writing the draft for my next article (I guess the file referenced was moved at some point?).