### PR TITLE
Fix minor misspellings in help text

### DIFF
--- a/tools/help
+++ b/tools/help
@@ -116,7 +116,7 @@ show_help()
 ### MAIN
 ${ECHO} "${BOLD}CBSD version:                  ${H3_COLOR}${myversion}${N0_COLOR}" 1>&2
 ${ECHO} "${BOLD}CBSD documentation:            ${H3_COLOR}https://bsdstore.ru/en/docs.html${N0_COLOR}" 1>&2
-${ECHO} "${BOLD}CBSD Telergam user group chat: ${H3_COLOR}https://t.me/cbsdofficial${N0_COLOR}" 1>&2
+${ECHO} "${BOLD}CBSD Telegram user group chat: ${H3_COLOR}https://t.me/cbsdofficial${N0_COLOR}" 1>&2
 echo 1>&2
 ${ECHO} "${BOLD}${UNDERLINE}Available commands:${N0_COLOR}" 1>&2
 [ -z "${module}" ] && ${ECHO} "\n Hint: use 'cbsd help module=<module>' to filter list." 1>&2

--- a/tools/pkgbrowsecat
+++ b/tools/pkgbrowsecat
@@ -2,7 +2,7 @@
 #v10.1.2
 MYARG="name controlmaster"
 MYOPTARG=""
-MYDESC="Generate choosen package list from repository"
+MYDESC="Generate chosen package list from repository"
 ADDHELP="out=path_to_file with result, instead of random\n\
 repo= use this repository\n\
 conf= use this pkg.conf\n"

--- a/tools/pkgbrowser
+++ b/tools/pkgbrowser
@@ -2,7 +2,7 @@
 #v10.1.2
 MYARG=
 MYOPTARG="conf controlmaster out repo"
-MYDESC="Generate choosen package list from repository"
+MYDESC="Generate chosen package list from repository"
 CBSDMODULE="jail"
 ADDHELP="
 ${H3_COLOR}Description${N0_COLOR}:


### PR DESCRIPTION
Typos caught in a cursory glance at `cbsd --help` output were fixed.