### PR TITLE
Expose ability to limit redirect to source IPs

### DIFF
--- a/share/system-expose.schema
+++ b/share/system-expose.schema
@@ -1,12 +1,13 @@
 # Default SQL scheme for DB nodes::nodelist
 #MYTABLE="expose"
-MYCOL="pin pout proto inaddr outaddr"
+MYCOL="pin pout proto inaddr outaddr fromips"
 
 pin="INTEGER"
 pout="INTEGER"
 proto="VARCHAR(5) DEFAULT 'tcp'"
 inaddr="VARCHAR(128) DEFAULT 'nodeip'"
 outaddr="VARCHAR(128) DEFAULT ''"
+fromips="VARCHAR(128) NOT NULL DEFAULT 'any'"
 
 INITDB=""
 CONSTRAINT=""

--- a/tools/expose
+++ b/tools/expose
@@ -255,9 +255,9 @@ fw_expose_add()
 	fi
 
 	if [ -z "${fromips}" ]; then
-		${ECHO} "\$fromips var is empty: $fromips"
-		${fromips:='any'}
-		${ECHO} "\$fromips var now modifed: $fromips"
+		#${ECHO} "\$fromips var is empty: $fromips"
+		${fromips:='any'} 2> /dev/null
+		#${ECHO} "\$fromips var now modifed: $fromips"
 	fi
 
 	[ -f ${ftmpdir}/${jname}-expose_fwnum ] && fwnum=$( ${CAT_CMD} ${ftmpdir}/${jname}-expose_fwnum )
@@ -435,9 +435,9 @@ fw_expose_clear()
 fw_expose_delete()
 {
 	if [ -z "${fromips}" ]; then
-		${ECHO} "\$fromips var is empty: $fromips"
-		${fromips:='any'}
-		${ECHO} "\$fromips var now modifed: $fromips"
+		#${ECHO} "\$fromips var is empty: $fromips"
+		${fromips:='any'} 2> /dev/null
+		#${ECHO} "\$fromips var now modifed: $fromips"
 	fi
 
 	if [ "${inaddr}" = "nodeip" -o "${inaddr}" = "0" ]; then

--- a/tools/expose
+++ b/tools/expose
@@ -1,7 +1,7 @@
 #!/usr/local/bin/cbsd
-#v13.0.11
+#v13.0.12
 MYARG=""
-MYOPTARG="in inaddr jname mode out outaddr proto"
+MYOPTARG="in inaddr jname mode out outaddr proto fromips"
 MYDESC="Exposing a port (port forwarding) to env via IPFW or PF"
 ADDHELP="
 ${H3_COLOR}Description${N0_COLOR}:
@@ -36,12 +36,18 @@ ${H3_COLOR}Options${N0_COLOR}:
  ${N2_COLOR}outaddr${N0_COLOR} - use IP as destination address, do not
            use jail/bhyve IPs.
  ${N2_COLOR}proto${N0_COLOR}   - udp, tcp. default: tcp.
+ ${N2_COLOR}fromips${N0_COLOR} - allowed IP address list of the port forward. default: any.
 
 ${H3_COLOR}Examples${N0_COLOR}:
 
 1) Forward all incoming traffic to \$nodeip:2233 to foo:22 jail:
 
  # cbsd expose mode=add in=2233 out=22 jname=foo
+ 
+  Or the same with specifying source IPs which can access the very port forward. Not specifying IPs adds 'any' to the pf rules:
+
+ # cbsd expose mode=add in=2233 out=22 fromips=8.8.8.8 jname=foo
+ # cbsd expose mode=add in=2233 out=22 fromips=8.8.8.8,1.1.1.1 jname=foo
 
   Or via CBSDfile (the 'jname=' args can be ommited):
 --
@@ -51,7 +57,7 @@ jail_foo()
 
 postcreate_foo()
 {
-    expose mode=add in=2233 out=22
+    expose mode=add in=2233 out=22 fromips=8.8.8.8,1.1.1.1
 }
 
 2) map (forward) all 1:1 traffic (tcp/udp) from EXT_IP4 <-> VM IP address
@@ -248,6 +254,12 @@ fw_expose_add()
 		return 1
 	fi
 
+	if [ -z "${fromips}" ]; then
+		${ECHO} "\$fromips var is empty: $fromips"
+		${fromips:='any'}
+		${ECHO} "\$fromips var now modifed: $fromips"
+	fi
+
 	[ -f ${ftmpdir}/${jname}-expose_fwnum ] && fwnum=$( ${CAT_CMD} ${ftmpdir}/${jname}-expose_fwnum )
 
 	case "${in}" in
@@ -256,8 +268,8 @@ fw_expose_add()
 			cbsdlogger NOTICE ${CBSD_APP}: ${jname}: ALL ${_inaddr}:${jip}
 			;;
 		*)
-			${ECHO} "${N1_COLOR}CBSD Expose for ${jname}: ${N2_COLOR}${in} -> ${out} (${proto})${N0_COLOR}"
-			cbsdlogger NOTICE ${CBSD_APP}: ${jname}: proto: ${proto}: ${in}:${out}
+			${ECHO} "${N1_COLOR}CBSD Expose for ${jname}: ${N2_COLOR}${in} -> ${out} (${proto})${N0_COLOR} from IPs (${fromips})${N0_COLOR}"
+			cbsdlogger NOTICE ${CBSD_APP}: ${jname}: proto: ${proto}: ${in}:${out} from IPs: ${fromips}
 			;;
 	esac
 
@@ -314,12 +326,12 @@ fw_expose_add()
 #nat pass on ${_pass_iface} from ${jip}/32 to !${rfcnet} -> ${_inaddr} # ${COMMENT}
 #EOF
 
-					cbsdlogger NOTICE "${CBSD_APP}: rdr pass proto {tcp, udp} from any to ${_inaddr}/32 -> ${jip}/32"
+					cbsdlogger NOTICE "${CBSD_APP}: rdr pass proto {tcp, udp} from ${fromips} to ${_inaddr}/32 -> ${jip}/32"
 					cbsdlogger NOTICE "${CBSD_APP}: nat pass from ${jip}/32 to !${rfcnet} -> ${_inaddr}"
 
 					# RDR
 					${CAT_CMD} >> ${etcdir}/pfrdr.conf <<EOF
-rdr pass proto {tcp, udp} from any to ${_inaddr}/32 -> ${jip}/32 # ${COMMENT}
+rdr pass proto {tcp, udp} from {${fromips}} to ${_inaddr}/32 -> ${jip}/32 # ${COMMENT}
 EOF
 					# NAT
 					${CAT_CMD} >> ${etcdir}/pfnat.conf <<EOF
@@ -329,7 +341,7 @@ EOF
 				*)
 					# RDR
 					${CAT_CMD} >> ${etcdir}/pfrdr.conf << EOF
-rdr pass proto ${proto} from any to ${_inaddr} port ${in} -> ${jip} port ${out} # ${COMMENT}
+rdr pass proto ${proto} from {${fromips}} to ${_inaddr} port ${in} -> ${jip} port ${out} # ${COMMENT}
 EOF
 					;;
 			esac
@@ -351,8 +363,8 @@ EOF
 
 fw_expose_apply()
 {
-	cbsdsqlro ${exposefile} SELECT pin,pout,proto,inaddr FROM expose | ${TR_CMD} "|" " " | while read in out proto inaddr; do
-		COMMENT="// Setup by CBSD expose: ${proto}-${out}-${jname}"
+	cbsdsqlro ${exposefile} SELECT pin,pout,proto,inaddr,fromips FROM expose | ${TR_CMD} "|" " " | while read in out proto inaddr fromips; do
+		COMMENT="// Setup by CBSD expose: ${proto}-${out}-${jname} from IPs ${fromips}"
 		fw_expose_add
 	done
 }
@@ -366,7 +378,7 @@ fw_expose_list()
 
 	[ ! -r ${exposefile} ] && return 1
 
-	cbsdsqlro ${exposefile} SELECT pin,pout,proto,inaddr FROM expose | ${TR_CMD} "|" " " | while read in out proto inaddr; do
+	cbsdsqlro ${exposefile} SELECT pin,pout,proto,inaddr,fromips FROM expose | ${TR_CMD} "|" " " | while read in out proto inaddr fromips; do
 
 		case "${inaddr}" in
 			nodeip|0)
@@ -382,7 +394,7 @@ fw_expose_list()
 				echo "map all via ${_inaddr}"
 				;;
 			*)
-				echo "${in} -> ${out} (${_inaddr} ${proto})"
+				echo "${in} -> ${out} from ${fromips} (${_inaddr} ${proto})"
 				;;
 		esac
 	done
@@ -422,11 +434,17 @@ fw_expose_clear()
 
 fw_expose_delete()
 {
+	if [ -z "${fromips}" ]; then
+		${ECHO} "\$fromips var is empty: $fromips"
+		${fromips:='any'}
+		${ECHO} "\$fromips var now modifed: $fromips"
+	fi
+
 	if [ "${inaddr}" = "nodeip" -o "${inaddr}" = "0" ]; then
 		inaddr="${nodeip}"
-		cbsdsqlrw ${exposefile} "DELETE FROM expose WHERE pin=${in} AND pout=${out} AND proto=\"${proto}\" AND ( inaddr=\"${inaddr}\" OR inaddr=\"0\" ) AND outaddr=\"${outaddr}\""
+		cbsdsqlrw ${exposefile} "DELETE FROM expose WHERE pin=${in} AND pout=${out} AND proto=\"${proto}\" AND ( inaddr=\"${inaddr}\" OR inaddr=\"0\" ) AND outaddr=\"${outaddr}\" AND fromips=\"${fromips}\""
 	else
-		cbsdsqlrw ${exposefile} "DELETE FROM expose WHERE pin=${in} AND pout=${out} AND proto=\"${proto}\" AND inaddr=\"${inaddr}\" AND outaddr=\"${outaddr}\""
+		cbsdsqlrw ${exposefile} "DELETE FROM expose WHERE pin=${in} AND pout=${out} AND proto=\"${proto}\" AND inaddr=\"${inaddr}\" AND outaddr=\"${outaddr}\" AND fromips=\"${fromips}\""
 	fi
 	cbsdlogger NOTICE ${CBSD_APP}: fw_expose_delete: delete config for: ${jname}
 
@@ -535,7 +553,7 @@ else
 	[ -z "${out}" ] && err 1 "${N1_COLOR}Empty ${N2_COLOR}out${N0_COLOR}"
 fi
 
-COMMENT="// Setup by CBSD expose: ${proto}-${out}-${jname}"
+COMMENT="// Setup by CBSD expose: ${proto}-${out}-${jname} from IPs ${fromips}"
 
 case "${mode}" in
 	add)
@@ -543,9 +561,9 @@ case "${mode}" in
 		ret=$?
 		if [ ${ret} -eq 0 ]; then
 			# check for dup
-			_res=$( cbsdsqlro ${exposefile} "SELECT pin FROM expose WHERE pin=${pin} AND pout=${pout} AND proto=\"${proto}\" AND inaddr=\"${inaddr}\" AND outaddr=\"${outaddr}\"" | ${HEAD_CMD} -n 1 )
-			[ -n "${_res}" ] && err 1 "${N1_COLOR}${CBSD_APP}: already exist in DB: pin=${pin} AND pout=${pout} AND proto=\"${proto}\" AND inaddr=\"${inaddr}\" AND outaddr=\"${outaddr}\""
-			cbsdsqlrw ${exposefile} "INSERT INTO expose ( pin, pout, proto, inaddr, outaddr ) VALUES ( ${in}, ${out}, \"${proto}\", \"${inaddr}\", \"${outaddr}\" )"
+			_res=$( cbsdsqlro ${exposefile} "SELECT pin FROM expose WHERE pin=${pin} AND pout=${pout} AND proto=\"${proto}\" AND inaddr=\"${inaddr}\" AND outaddr=\"${outaddr}\" AND fromips=\"${fromips}\"" | ${HEAD_CMD} -n 1 )
+			[ -n "${_res}" ] && err 1 "${N1_COLOR}${CBSD_APP}: already exist in DB: pin=${pin} AND pout=${pout} AND proto=\"${proto}\" AND inaddr=\"${inaddr}\" AND outaddr=\"${outaddr}\" AND fromips=\"${fromips}\""
+			cbsdsqlrw ${exposefile} "INSERT INTO expose ( pin, pout, proto, inaddr, outaddr, fromips ) VALUES ( ${in}, ${out}, \"${proto}\", \"${inaddr}\", \"${outaddr}\", \"${fromips}\" )"
 		else
 			err 1 "${N1_COLOR}${CBSD_APP}: fw_expose_add error: ${ret}${N0_COLOR}"
 		fi


### PR DESCRIPTION
Connected to issue #761 the first batch of changes in a PR -> extending expose to be able to handle source IP limitations on jail (bhyve[?]) redirects. 

Looking for the expansion of CBSD, ClonOS, myBee, XigmaNAS plugins, QT app, I think its fits into to direction, eg. CBSD can have better FW control and be able to merge into / handle host's own pf (beside the existing %CBSDWORKDIR%/etc/pf.conf) 

These commits add:
- additional column to system-wide expose sqlite shema,
- adds the capability to tools/expose to specify source IPs for redirects

To be added -> howto handle the existing host pf.conf:
- the logic and oneliners can be used from my last comment from #761
- question is where to add the subroutine, expose, naton, natcfg

@olevole,

I've had difficulties make work the SQLite's default values even with "NOT NULL". If you know the working way, please let me know -> two exception handling can be removed.

Also, no migration script added:
- existing tables to be upgraded,
- more interesting: existong pfrdr.conf to be managed (or recreated). The harder