### PR TITLE
Fix a couple of typos

### DIFF
--- a/etc/defaults/color-white.conf
+++ b/etc/defaults/color-white.conf
@@ -6,13 +6,13 @@ N0_COLOR="${NORMAL}"			# disable color
 N1_COLOR="${BLACK}"			# normal default CBSD text color
 N2_COLOR="${BLACK}"			# normal second CBSD color
 N3_COLOR="${BLACK}"			# normal third CBSD color
-N4_COLOR="${BLACK}"			# normal third CBSD color
+N4_COLOR="${BLACK}"			# normal fourth CBSD color
 
-H1_COLOR="${BLACK}"			# highlight CBSD color
-H2_COLOR="${BLACK}"			# highlight CBSD color
-H3_COLOR="${BLACK}"			# highlight CBSD color
-H4_COLOR="${BLACK}"			# highlight CBSD color
-H5_COLOR="${BLACK}"			# highlight CBSD color
+H1_COLOR="${BLACK}"			# highlight CBSD color 1
+H2_COLOR="${BLACK}"			# highlight CBSD color 2
+H3_COLOR="${BLACK}"			# highlight CBSD color 3
+H4_COLOR="${BLACK}"			# highlight CBSD color 4
+H5_COLOR="${BLACK}"			# highlight CBSD color 5
 
 W1_COLOR="${LRED}"			# warning CBSD color 1
 W2_COLOR="${RED}"			# warning CBSD color 2

--- a/etc/defaults/color.conf
+++ b/etc/defaults/color.conf
@@ -7,13 +7,13 @@ N0_COLOR="${NORMAL}"			# disable color
 N1_COLOR="${GRAY}"			# normal default CBSD text color
 N2_COLOR="${CYAN}"			# normal second CBSD color
 N3_COLOR="${DGRAY}"			# normal third CBSD color
-N4_COLOR="${DGRAY}"			# normal third CBSD color
+N4_COLOR="${DGRAY}"			# normal fourth CBSD color
 
-H1_COLOR="${BLACK}"			# highlight CBSD color
-H2_COLOR="${LGREEN}"			# highlight CBSD color
-H3_COLOR="${LYELLOW}"			# highlight CBSD color
-H4_COLOR="${YELLOW}"			# highlight CBSD color
-H5_COLOR="${LCYAN}"			# highlight CBSD color
+H1_COLOR="${BLACK}"			# highlight CBSD color 1
+H2_COLOR="${LGREEN}"			# highlight CBSD color 2
+H3_COLOR="${LYELLOW}"			# highlight CBSD color 3
+H4_COLOR="${YELLOW}"			# highlight CBSD color 4
+H5_COLOR="${LCYAN}"			# highlight CBSD color 5
 
 W1_COLOR="${LRED}"			# warning CBSD color 1
 W2_COLOR="${RED}"			# warning CBSD color 2

--- a/etc/defaults/jail-freebsd-default.conf
+++ b/etc/defaults/jail-freebsd-default.conf
@@ -14,7 +14,7 @@ jail_active="1"
 long_description="New empty jail"
 
 # jail name suggestion settings.
-# freejname_script - helper for next free jail name recomendatin
+# freejname_script - helper for next free jail name recommendation
 # To use internal 'cbsd freejname' script, leave it as
 #
 # freejname_script="freejname"

--- a/etc/defaults/vm-freebsd-OPNsense-24-RELEASE-amd64.conf
+++ b/etc/defaults/vm-freebsd-OPNsense-24-RELEASE-amd64.conf
@@ -43,7 +43,7 @@ iso_extract="nice -n 19 ${IDLE_IONICE} ${BZIP2_CMD} -d ${iso_img_dist}"
 # HBSD based, needs bhyve_ignore_msr_acc=1
 bhyve_ignore_msr_acc=1
 
-# OPNSense recomendation: 2g/4g
+# OPNSense recommendation: 2g/4g
 vm_ram=2g
 imgsize="4g"
 

--- a/etc/defaults/vm-freebsd-cloud-OPNSense-22-RELEASE-amd64-22.conf
+++ b/etc/defaults/vm-freebsd-cloud-OPNSense-22-RELEASE-amd64-22.conf
@@ -48,7 +48,7 @@ vm_efi="uefi"
 
 vm_package="small1"
 
-# OPNSense recomendation: 2g/4g
+# OPNSense recommendation: 2g/4g
 vm_ram=2g
 imgsize="4g"
 

--- a/etc/defaults/vm-freebsd-cloud-XigmaNAS-13-amd64.conf
+++ b/etc/defaults/vm-freebsd-cloud-XigmaNAS-13-amd64.conf
@@ -52,7 +52,7 @@ vm_efi="uefi"
 
 vm_package="small1"
 
-# XigmaNAS recomendation: 2g/5g
+# XigmaNAS recommendation: 2g/5g
 vm_ram="2g"
 imgsize="5g"
 imgsize_min="2g"

--- a/subr/ansiicolor.subr
+++ b/subr/ansiicolor.subr
@@ -58,13 +58,13 @@ if [ -z "${NOCOLOR}" ]; then
 	N0_COLOR="${NORMAL}"			# disable color
 	N1_COLOR="${MAGENTA}"			# normal default CBSD text color
 	N2_COLOR="${GREEN}"			# normal second CBSD color
-	N4_COLOR="${CYAN}"			# normal third CBSD color
+	N4_COLOR="${CYAN}"			# normal fourth CBSD color
 
-	H1_COLOR="${WHITE}"			# highlight CBSD color
-	H2_COLOR="${LGREEN}"			# highlight CBSD color
-	H3_COLOR="${LYELLOW}"			# highlight CBSD color
-	H4_COLOR="${YELLOW}"			# highlight CBSD color
-	H5_COLOR="${LCYAN}"			# highlight CBSD color
+	H1_COLOR="${WHITE}"			# highlight CBSD color 1
+	H2_COLOR="${LGREEN}"			# highlight CBSD color 2
+	H3_COLOR="${LYELLOW}"			# highlight CBSD color 3
+	H4_COLOR="${YELLOW}"			# highlight CBSD color 4
+	H5_COLOR="${LCYAN}"			# highlight CBSD color 5
 
 	W1_COLOR="${LRED}"			# warning CBSD color 1
 	W2_COLOR="${RED}"			# warning CBSD color 2

--- a/upgrade/backup_db/pre-initenv-backup
+++ b/upgrade/backup_db/pre-initenv-backup
@@ -27,7 +27,7 @@ done
 
 [ ${_total_env} -eq 0 ] && exit 0
 
-echo "${CBSD_APP} in progress ( can be disabled via ~cbsd/etc/initenv.conf ): initenv_backup_bases=${initenv_backup_bases}"
+echo "${CBSD_APP} in progress ( can be disabled via ~cbsd/etc/defaults/initenv.conf ): initenv_backup_bases=${initenv_backup_bases}"
 DT=$( date "+%Y%m%d%H%M%S" )
 
 for i in ${ALL_JAILS} ${ALL_BHYVE} ${ALL_QEMU} ${ALL_XEN}; do

--- a/upgrade/backup_db/pre-initenv-backup
+++ b/upgrade/backup_db/pre-initenv-backup
@@ -27,7 +27,7 @@ done
 
 [ ${_total_env} -eq 0 ] && exit 0
 
-echo "${CBSD_APP} in progress ( can be disabled via ~cbsd/etc/defaults/initenv.conf ): initenv_backup_bases=${initenv_backup_bases}"
+echo "${CBSD_APP} in progress ( can be disabled via ~cbsd/etc/initenv.conf; see ~cbsd/etc/defaults/initenv.conf ): initenv_backup_bases=${initenv_backup_bases}"
 DT=$( date "+%Y%m%d%H%M%S" )
 
 for i in ${ALL_JAILS} ${ALL_BHYVE} ${ALL_QEMU} ${ALL_XEN}; do


### PR DESCRIPTION
Here's fixes for a couple of typos that I found. Regarding `ansiicolor.subr` I'm not entirely sure if this is correct or complete as a N3_COLOR definition is missing. The only potentially important fix is making the db backup script output the correct directory so users have an easier time to find the configuration file!