### PR TITLE
make default racct-jail-statsd.conf more neutral

### DIFF
--- a/etc/defaults/racct-jail-statsd.conf
+++ b/etc/defaults/racct-jail-statsd.conf
@@ -5,7 +5,7 @@ log_level=0					# default log level
 loop_interval=1					# interval between collectict next metrics, in seconds
 save_loop_count=5				# save/export frequency of average values ( real save/export: loop_interval * save_loop_count )
 prometheus_exporter_enable=NO			# enable prometheus_exporter ?
-beanstald_enable=YES				# save/export metrics to beanstalkd broker
+beanstald_enable=NO				# save/export metrics to beanstalkd broker
 sqlite3_enable=YES				# save metrics to SQLite3 databse?
 pool_name=					# (prometheus only) set as poolname or hostname (default)
 


### PR DESCRIPTION
fix default config for racct-jail-statsd.conf to do not refer beanstald by default