### PR TITLE
Minor update: defaults/jail-freebsd-vnet.conf

### DIFF
--- a/etc/defaults/jail-freebsd-vnet.conf
+++ b/etc/defaults/jail-freebsd-vnet.conf
@@ -3,7 +3,7 @@ jail_profile="vnet"
 
 # suggest for vnet1, vnet2, vnet3.
 default_jailname="vnet"
-default_domain="example.com"
+default_domain="my.domain"
 
 emulator="jail"
 jail_active="1"


### PR DESCRIPTION
All other defaults/jail-freebsd-*.conf templates use default_domain="my.domain" but vnet used "example.com". It was making me OCD. :P