### PR TITLE
Fix jail start with "unknown parameter: allow.nfsd"

### DIFF
--- a/tools/makejconf
+++ b/tools/makejconf
@@ -379,8 +379,7 @@ else
 fi
 
 # allow.nfsd
-nfs_feat=$( ${SYSCTL_CMD} -qn kern.features.nfsd 2>/dev/null )
-if [ "${nfs_feat}" = "1" ]; then
+if ${SYSCTL_CMD} -qn security.jail.param.allow.nfsd 2>/dev/null; then
 	# this feature available for FreeBSD 14.0+
 	if [ ${freebsdhostversion} -gt 1400090 ]; then
 		if [ "${allow_nfsd}" = "1" ]; then


### PR DESCRIPTION
Tested on a problematic instance. Not tested on a standard.