### PR TITLE
Fix cbsd jname glob matching starting from non-star

### DIFF
--- a/subr/tools.subr
+++ b/subr/tools.subr
@@ -555,11 +555,10 @@ jname_is_multiple()
 
 	local jail_pref=$( substr --pos=0 --len=1 --str=${jname} )
 
-	if [ "${jail_pref}" = "*" ]; then
-		is_mask=1
+    if [ "$( substr --pos=0 --len=1 --str=${jname} )" == "*" ]; then
+        is_mask=1
 	else
-		strpos --str="${jname}" --search="*"
-		is_mask=$?
+		strpos --str="${jname}" --search="*" || is_mask=1
 	fi
 
 	if [ ${is_mask} -ne 0 ]; then


### PR DESCRIPTION
  Fix cases like cbsd jstart jname='www*'
  Before it work only in cases when the pattern starts with star