### PR TITLE
Add jailnic CLI command and improve NIC naming

### DIFF
--- a/jailctl/jailnic
+++ b/jailctl/jailnic
@@ -2,7 +2,7 @@
 #v15.0.1
 CBSDMODULE="jail"
 MYARG=""
-MYOPTARG="jname mode name slot interface hwaddr address mtu flags vlan_untagged vlan_tagged header display new_name"
+MYOPTARG="jname mode name slot interface hwaddr address mtu flags vlan_untagged vlan_tagged header display new_name untagged tagged"
 MYDESC="Manage jail vnet NIC"
 ADDHELP="
 ${H3_COLOR}Description${N0_COLOR}:
@@ -137,6 +137,10 @@ case "${mode}" in
 		init --help
 		;;
 esac
+
+# normalize vlan_untagged and vlan_tagged
+[ -z "${vlan_tagged}"   -a -n "${tagged}"   ] && vlan_tagged="${tagged}"
+[ -z "${vlan_untagged}" -a -n "${untagged}" ] && vlan_untagged="${untagged}"
 
 #
 # List NICs

--- a/jailctl/jailnic
+++ b/jailctl/jailnic
@@ -1,0 +1,367 @@
+#!/usr/local/bin/cbsd
+#v15.0.1
+CBSDMODULE="jail"
+MYARG=""
+MYOPTARG="jname mode name slot interface hwaddr address mtu flags vlan_untagged vlan_tagged header display new_name"
+MYDESC="Manage jail vnet NIC"
+ADDHELP="
+${H3_COLOR}Description${N0_COLOR}:
+
+Manage virtual network interfaces for vnet-based jails.
+
+${H3_COLOR}Usage${N0_COLOR}:
+
+ cbsd jailnic mode=list jname=<jail>
+ cbsd jailnic mode=add jname=<jail> [name=ethX] [interface=auto] ...
+ cbsd jailnic mode=update jname=<jail> name=<nic> [interface=...] ...
+ cbsd jailnic mode=delete jname=<jail> name=<nic>
+
+${H3_COLOR}Options${N0_COLOR}:
+
+ ${N2_COLOR}mode= | arg1${N0_COLOR}    - action: list, add, update, delete (or del)
+ ${N2_COLOR}jname= | arg2${N0_COLOR}   - jail name
+ ${N2_COLOR}name= | arg3${N0_COLOR}    - NIC name, used as interface name inside jail (e.g., eth0, eth1)
+ ${N2_COLOR}slot=${N0_COLOR}           - NIC slot number
+ ${N2_COLOR}interface=${N0_COLOR}      - parent interface (auto, bridge0, em0, etc.)
+ ${N2_COLOR}hwaddr=${N0_COLOR}         - MAC address (0 = auto-generate)
+ ${N2_COLOR}address=${N0_COLOR}        - IP address for epairA host side (0 = disabled)
+ ${N2_COLOR}mtu=${N0_COLOR}            - MTU size (0 = inherit from parent)
+ ${N2_COLOR}flags=${N0_COLOR}          - NIC flags: private (bridge isolation)
+ ${N2_COLOR}vlan_untagged=${N0_COLOR}  - untagged VLAN ID for bridge addm (0 = disabled)
+ ${N2_COLOR}vlan_tagged=${N0_COLOR}    - tagged VLAN set, comma-separated (0 = disabled)
+ ${N2_COLOR}header=${N0_COLOR}         - show header in list mode (1 = yes, 0 = no)
+ ${N2_COLOR}display=${N0_COLOR}        - comma-separated columns to display
+
+${H3_COLOR}Examples${N0_COLOR}:
+
+ # cbsd jailnic jail1 list
+ # cbsd jailnic jail1 add interface=bridge0 vlan_untagged=100
+ # cbsd jailnic jail1 update nic1 mtu=1400 flags=private
+ # cbsd jailnic jail1 update nic1 name=nic8
+ # cbsd jailnic jail1 delete nic1
+
+
+ # cbsd jailnic jname=jail1 mode=list
+ # cbsd jailnic jname=jail1 mode=add interface=bridge0 vlan_untagged=100
+ # cbsd jailnic jname=jail1 mode=update name=nic1 mtu=1400 flags=private
+ # cbsd jailnic jname=jail1 mode=delete name=nic1
+
+
+${H3_COLOR}See also${N0_COLOR}:
+
+ cbsd jailnic-tui --help
+ cbsd jstart --help
+
+"
+
+. ${subrdir}/nc.subr
+. ${strings}
+. ${tools}
+
+. ${cbsdinit}
+
+# Normalize arguments: drop all x=y args
+normalize_argv() {
+	local args=""
+	local space=""
+	for arg in "$@"; do
+		case "${arg}" in
+			*=*)
+				# skip x=y args
+				;;
+			*)
+				args="${args}${space}${arg}"
+				space=" "
+				;;
+		esac
+	done
+	echo "${args}"
+}
+
+# Handle positional arguments: jailnic <mode> <jname> [name]
+# e.g.: cbsd jailnic list myjail
+#       cbsd jailnic delete myjail eth0
+
+set -- $(normalize_argv "$@")
+[ -z "${jname}" -a -n "${1}" ] && jname="${1}" && shift
+[ -z "${mode}"  -a -n "${1}" ] && mode="${1}" && shift
+
+if [ -n "${1}" ]; then
+	if [ -z "${name}" ]; then
+		name="${1}"
+	else
+		# rename case
+		new_name="${name}"  # name suppied as name=xxx
+		name="${1}"  		# name supplied as positional argument
+	fi
+	shift
+fi
+
+if [ -n "${1}" ]; then
+	err 1 "${N1_COLOR}jailnic: too many arguments: ${N2_COLOR}${1}${N0_COLOR}"
+fi
+
+# Defaults
+[ -z "${header}" ] && header=1
+[ -z "${display}" ] && display="name,nic_slot,nic_parent,nic_hwaddr,nic_mtu,nic_flags,nic_vlan_untagged,nic_vlan_tagged"
+
+# Validate jname
+[ -z "${jname}" ] && err 1 "${N1_COLOR}jailnic: ${N2_COLOR}jname=${N1_COLOR} is required. Use ${N2_COLOR}help${N1_COLOR} for usage.${N0_COLOR}"
+
+# Save 'name' before rcconf.subr (it unsets columns from local-jails.schema including 'name')
+_saved_nic_name="${name}"
+
+. ${subrdir}/rcconf.subr
+[ $? -eq 1 ] && err 1 "${N1_COLOR}jailnic: no such jail: ${N2_COLOR}${jname}${N0_COLOR}"
+
+# Restore 'name' after rcconf.subr
+name="${_saved_nic_name}"
+[ "${emulator}" != "jail" ] && err 1 "${N1_COLOR}jailnic: ${N2_COLOR}${jname}${N1_COLOR} is not a jail (emulator=${emulator})${N0_COLOR}"
+
+mysqlite="${jailsysdir}/${jname}/local.sqlite"
+
+# Ensure jailnic table exists
+if [ ! -r "${mysqlite}" ]; then
+	/usr/local/bin/cbsd ${miscdir}/updatesql ${mysqlite} ${CIX_DISTDIR}/share/local-jailnic.schema jailnic
+fi
+
+# Normalize mode
+case "${mode}" in
+	""|list)
+		mode="list"
+		;;
+	del|delete)
+		mode="delete"
+		;;
+	help)
+		init --help
+		;;
+esac
+
+#
+# List NICs
+#
+jailnic_list()
+{
+	local _sql _header_printed=0
+	local _id _name _nic_slot _nic_parent _nic_hwaddr _nic_address _nic_mtu _nic_flags _nic_vlan_untagged _nic_vlan_tagged
+
+	# Check if table exists
+	_table_exists=$( cbsdsqlro ${mysqlite} "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='jailnic';" )
+	if [ "${_table_exists}" = "0" ]; then
+		${ECHO} "${N1_COLOR}No NIC configuration for ${N2_COLOR}${jname}${N0_COLOR}"
+		return 0
+	fi
+
+	# Print header
+	if [ "${header}" = "1" ]; then
+		printf "${BOLD}"
+		local _dfields
+		_dfields=$( echo "${display}" | ${TR_CMD} ',' ' ' )
+		for _f in ${_dfields}; do
+			case "${_f}" in
+				name) printf "%-12s" "NAME" ;;
+				nic_slot|slot) printf "%-6s" "SLOT" ;;
+				nic_parent|interface) printf "%-14s" "INTERFACE" ;;
+				nic_hwaddr|hwaddr) printf "%-20s" "HWADDR" ;;
+				nic_address|address) printf "%-16s" "ADDRESS" ;;
+				nic_mtu|mtu) printf "%-6s" "MTU" ;;
+				nic_flags|flags) printf "%-10s" "FLAGS" ;;
+				nic_vlan_untagged|vlan_untagged) printf "%-10s" "UNTAGGED" ;;
+				nic_vlan_tagged|vlan_tagged) printf "%-14s" "TAGGED" ;;
+			esac
+		done
+		printf "${N0_COLOR}\n"
+	fi
+
+	# Query and display
+	cbsdsqlro ${mysqlite} "SELECT name,nic_slot,nic_parent,nic_hwaddr,nic_address,nic_mtu,nic_flags,nic_vlan_untagged,nic_vlan_tagged FROM jailnic" | while read _line; do
+		local IFS="|"
+		set -- ${_line}
+		_name="${1}"
+		_nic_slot="${2}"
+		_nic_parent="${3}"
+		_nic_hwaddr="${4}"
+		_nic_address="${5}"
+		_nic_mtu="${6}"
+		_nic_flags="${7}"
+		_nic_vlan_untagged="${8}"
+		_nic_vlan_tagged="${9}"
+		IFS=" "
+
+		local _dfields
+		_dfields=$( echo "${display}" | ${TR_CMD} ',' ' ' )
+		for _f in ${_dfields}; do
+			case "${_f}" in
+				name) printf "%-12s" "${_name}" ;;
+				nic_slot|slot) printf "%-6s" "${_nic_slot}" ;;
+				nic_parent|interface) printf "%-14s" "${_nic_parent}" ;;
+				nic_hwaddr|hwaddr) printf "%-20s" "${_nic_hwaddr}" ;;
+				nic_address|address) printf "%-16s" "${_nic_address}" ;;
+				nic_mtu|mtu) printf "%-6s" "${_nic_mtu}" ;;
+				nic_flags|flags) printf "%-10s" "${_nic_flags}" ;;
+				nic_vlan_untagged|vlan_untagged) printf "%-10s" "${_nic_vlan_untagged}" ;;
+				nic_vlan_tagged|vlan_tagged) printf "%-14s" "${_nic_vlan_tagged}" ;;
+			esac
+		done
+		printf "\n"
+	done
+}
+
+#
+# Add NIC
+#
+jailnic_add()
+{
+	local _last_nic _last_slot _res
+
+	# Find next free NIC name if not specified (eth0, eth1, ...)
+	if [ -z "${name}" ]; then
+		for _last_nic in $( ${SEQ_CMD} 0 16 ); do
+			_res=$( cbsdsqlro ${mysqlite} "SELECT name FROM jailnic WHERE name='eth${_last_nic}'" 2>&1 )
+			[ -z "${_res}" ] && break
+		done
+		name="eth${_last_nic}"
+	fi
+
+	# Check if name already exists
+	_exists=$( cbsdsqlro ${mysqlite} "SELECT COUNT(*) FROM jailnic WHERE name='${name}'" )
+	[ "${_exists}" != "0" ] && err 1 "${N1_COLOR}jailnic: NIC ${N2_COLOR}${name}${N1_COLOR} already exists${N0_COLOR}"
+
+	# Find next free slot if not specified
+	if [ -z "${slot}" ]; then
+		for _last_slot in $( ${SEQ_CMD} 0 16 ); do
+			_res=$( cbsdsqlro ${mysqlite} "SELECT nic_slot FROM jailnic WHERE nic_slot=${_last_slot}" 2>&1 )
+			[ -z "${_res}" ] && break
+		done
+		slot="${_last_slot}"
+	fi
+
+	# Defaults
+	[ -z "${interface}" ] && interface="auto"
+	[ -z "${hwaddr}" ] && hwaddr="0"
+	[ -z "${address}" ] && address="0"
+	[ -z "${mtu}" ] && mtu="0"
+	[ -z "${flags}" ] && flags="0"
+	[ -z "${vlan_untagged}" ] && vlan_untagged="0"
+	[ -z "${vlan_tagged}" ] && vlan_tagged="0"
+
+	cbsdsqlrw ${mysqlite} "INSERT INTO jailnic ( name,nic_slot,nic_parent,nic_hwaddr,nic_address,nic_mtu,nic_flags,nic_vlan_untagged,nic_vlan_tagged ) VALUES ( '${name}', '${slot}', '${interface}', '${hwaddr}', '${address}', '${mtu}', '${flags}', '${vlan_untagged}', '${vlan_tagged}' )"
+
+	${ECHO} "${N1_COLOR}NIC ${N2_COLOR}${name}${N1_COLOR} added to ${N2_COLOR}${jname}${N0_COLOR}"
+	# Warn if jail is running
+	if [ "${jid}" != "0" -a -n "${jid}" ]; then
+		${ECHO} "${N1_COLOR}Note: jail is running, ${N2_COLOR}cbsd jrestart ${jname}${N1_COLOR} required to apply changes${N0_COLOR}"
+	fi
+}
+
+#
+# Update NIC
+#
+jailnic_update()
+{
+	[ -z "${name}" ] && err 1 "${N1_COLOR}jailnic update: ${N2_COLOR}name=${N1_COLOR} is required${N0_COLOR}"
+
+	# Check if NIC exists
+	_exists=$( cbsdsqlro ${mysqlite} "SELECT COUNT(*) FROM jailnic WHERE name='${name}'" )
+	[ "${_exists}" = "0" ] && err 1 "${N1_COLOR}jailnic: NIC ${N2_COLOR}${name}${N1_COLOR} not found${N0_COLOR}"
+
+	local _updated=0
+
+	if [ -n "${new_name}" ]; then
+		cbsdsqlrw ${mysqlite} "UPDATE jailnic SET name='${new_name}' WHERE name='${name}'"
+		name="${new_name}"
+		_updated=1
+	fi
+
+	if [ -n "${slot}" ]; then
+		cbsdsqlrw ${mysqlite} "UPDATE jailnic SET nic_slot='${slot}' WHERE name='${name}'"
+		_updated=1
+	fi
+
+	if [ -n "${interface}" ]; then
+		cbsdsqlrw ${mysqlite} "UPDATE jailnic SET nic_parent='${interface}' WHERE name='${name}'"
+		_updated=1
+	fi
+
+	if [ -n "${hwaddr}" ]; then
+		cbsdsqlrw ${mysqlite} "UPDATE jailnic SET nic_hwaddr='${hwaddr}' WHERE name='${name}'"
+		_updated=1
+	fi
+
+	if [ -n "${address}" ]; then
+		cbsdsqlrw ${mysqlite} "UPDATE jailnic SET nic_address='${address}' WHERE name='${name}'"
+		_updated=1
+	fi
+
+	if [ -n "${mtu}" ]; then
+		cbsdsqlrw ${mysqlite} "UPDATE jailnic SET nic_mtu='${mtu}' WHERE name='${name}'"
+		_updated=1
+	fi
+
+	if [ -n "${flags}" ]; then
+		cbsdsqlrw ${mysqlite} "UPDATE jailnic SET nic_flags='${flags}' WHERE name='${name}'"
+		_updated=1
+	fi
+
+	if [ -n "${vlan_untagged}" ]; then
+		cbsdsqlrw ${mysqlite} "UPDATE jailnic SET nic_vlan_untagged='${vlan_untagged}' WHERE name='${name}'"
+		_updated=1
+	fi
+
+	if [ -n "${vlan_tagged}" ]; then
+		cbsdsqlrw ${mysqlite} "UPDATE jailnic SET nic_vlan_tagged='${vlan_tagged}' WHERE name='${name}'"
+		_updated=1
+	fi
+
+	if [ ${_updated} -eq 1 ]; then
+		${ECHO} "${N1_COLOR}NIC ${N2_COLOR}${name}${N1_COLOR} updated in ${N2_COLOR}${jname}${N0_COLOR}"
+		# Warn if jail is running
+		if [ "${jid}" != "0" -a -n "${jid}" ]; then
+			${ECHO} "${N1_COLOR}Note: jail is running, ${N2_COLOR}cbsd jrestart ${jname}${N1_COLOR} required to apply changes${N0_COLOR}"
+		fi
+	else
+		${ECHO} "${N1_COLOR}No parameters specified to update${N0_COLOR}"
+	fi
+}
+
+#
+# Delete NIC
+#
+jailnic_delete()
+{
+	[ -z "${name}" ] && err 1 "${N1_COLOR}jailnic delete: ${N2_COLOR}name=${N1_COLOR} is required${N0_COLOR}"
+
+	# Check if NIC exists
+	_exists=$( cbsdsqlro ${mysqlite} "SELECT COUNT(*) FROM jailnic WHERE name='${name}'" )
+	[ "${_exists}" = "0" ] && err 1 "${N1_COLOR}jailnic: NIC ${N2_COLOR}${name}${N1_COLOR} not found${N0_COLOR}"
+
+	cbsdsqlrw ${mysqlite} "DELETE FROM jailnic WHERE name='${name}'"
+
+	${ECHO} "${N1_COLOR}NIC ${N2_COLOR}${name}${N1_COLOR} deleted from ${N2_COLOR}${jname}${N0_COLOR}"
+	# Warn if jail is running
+	if [ "${jid}" != "0" -a -n "${jid}" ]; then
+		${ECHO} "${N1_COLOR}Note: jail is running, ${N2_COLOR}cbsd jrestart ${jname}${N1_COLOR} required to apply changes${N0_COLOR}"
+	fi
+}
+
+# Main
+case "${mode}" in
+	list)
+		jailnic_list
+		;;
+	add)
+		jailnic_add
+		;;
+	update)
+		jailnic_update
+		;;
+	delete)
+		jailnic_delete
+		;;
+	*)
+		err 1 "${N1_COLOR}jailnic: unknown mode: ${N2_COLOR}${mode}${N1_COLOR}. Use: list, add, update, delete${N0_COLOR}"
+		;;
+esac
+
+exit 0

--- a/jailctl/jconstruct-tui
+++ b/jailctl/jconstruct-tui
@@ -391,7 +391,7 @@ while true; do
 			if [ -z "${jailnic_temp_sql}" ]; then
 				jailnic_temp_sql=$( ${MKTEMP_CMD} )
 				/usr/local/bin/cbsd "${miscdir}"/updatesql "${jailnic_temp_sql}" "${CIX_DISTDIR}"/share/local-jailnic.schema jailnic
-				cbsdsqlrw "${jailnic_temp_sql}" "INSERT INTO jailnic ( name,nic_order,nic_slot,nic_parent,nic_hwaddr,nic_mtu,nic_flags,nic_vlan_untagged,nic_vlan_tagged ) VALUES ( 'epairb','0','0','auto','${nic_hwaddr}','0','0','0','0' )"
+				cbsdsqlrw "${jailnic_temp_sql}" "INSERT INTO jailnic ( name,nic_order,nic_slot,nic_parent,nic_hwaddr,nic_mtu,nic_flags,nic_vlan_untagged,nic_vlan_tagged ) VALUES ( 'eth0','0','0','auto','${nic_hwaddr}','0','0','0','0' )"
 				# shellcheck disable=2064
 				trap "${RM_CMD} -f ${jailnic_temp_sql} ${jailnic_temp_sql}-shm ${jailnic_temp_sql}-wal" HUP INT ABRT BUS TERM EXIT
 			fi

--- a/share/bsdconfig/cbsd/include/jailnic.subr
+++ b/share/bsdconfig/cbsd/include/jailnic.subr
@@ -39,9 +39,9 @@ find_first_free_nic_id()
 {
 	local last_nic _res
 
-	for last_nic in $( ${SEQ_CMD} 1 16 ); do
+	for last_nic in $( ${SEQ_CMD} 0 15 ); do
 		unset _res
-		_res=$( cbsdsqlro ${mysqlite} SELECT name FROM jailnic WHERE name=\"nic${last_nic}\" 2>&1 )
+		_res=$( cbsdsqlro ${mysqlite} SELECT name FROM jailnic WHERE name=\"eth${last_nic}\" 2>&1 )
 		[ -z "${_res}" ] && break
 	done
 
@@ -128,6 +128,8 @@ add_nic()
 	local nic_flags=
 	local nic_vlan_untagged=
 	local nic_vlan_tagged=
+	local nic_slot=
+	local _last_slot _res
 
 	while getopts "f:h:m:n:p:t:u:z:" opt; do
 		case "${opt}" in
@@ -153,7 +155,14 @@ add_nic()
 	[ -z "${nic_name}" ] && err 1 "${N1_COLOR}Empty nic_name${N0_COLOR}"
 	[ -z "${nic_hwaddr}" ] && err 1 "${N1_COLOR}Empty nic_hwaddr${N0_COLOR}"
 
-	cbsdsqlrw ${mysqlite} "INSERT INTO jailnic ( name,nic_parent,nic_hwaddr,nic_persistent,nic_mtu,nic_flags,nic_vlan_untagged,nic_vlan_tagged ) VALUES ( '${nic_name}', '${nic_parent}', '${nic_hwaddr}', '${nic_persistent}', '${nic_mtu}', '${nic_flags}', '${nic_vlan_untagged}', '${nic_vlan_tagged}' )"
+	# Find next free slot
+	for _last_slot in $( ${SEQ_CMD} 0 16 ); do
+		_res=$( cbsdsqlro ${mysqlite} "SELECT nic_slot FROM jailnic WHERE nic_slot=${_last_slot}" 2>&1 )
+		[ -z "${_res}" ] && break
+	done
+	nic_slot="${_last_slot}"
+
+	cbsdsqlrw ${mysqlite} "INSERT INTO jailnic ( name,nic_slot,nic_parent,nic_hwaddr,nic_persistent,nic_mtu,nic_flags,nic_vlan_untagged,nic_vlan_tagged ) VALUES ( '${nic_name}', '${nic_slot}', '${nic_parent}', '${nic_hwaddr}', '${nic_persistent}', '${nic_mtu}', '${nic_flags}', '${nic_vlan_untagged}', '${nic_vlan_tagged}' )"
 
 	return 0
 }

--- a/share/bsdconfig/cbsd/jailnic
+++ b/share/bsdconfig/cbsd/jailnic
@@ -103,7 +103,7 @@ else
 	mysqlite="${out}"
 	if [ ! -r ${mysqlite} ]; then
 		/usr/local/bin/cbsd ${miscdir}/updatesql ${mysqlite} ${CIX_DISTDIR}/share/local-jailnic.schema jailnic
-		cbsdsqlrw ${mysqlite} "INSERT INTO jailnic ( name,nic_order,nic_slot,nic_parent,nic_hwaddr,nic_address,nic_mtu,nic_flags,nic_vlan_untagged,nic_vlan_tagged ) VALUES ( 'epairb','0','0','auto','${nic_hwaddr}','${nic_address}','0','0','0','0' )"
+		cbsdsqlrw ${mysqlite} "INSERT INTO jailnic ( name,nic_order,nic_slot,nic_parent,nic_hwaddr,nic_address,nic_mtu,nic_flags,nic_vlan_untagged,nic_vlan_tagged ) VALUES ( 'eth0','0','0','auto','${nic_hwaddr}','${nic_address}','0','0','0','0' )"
 	fi
 fi
 
@@ -142,7 +142,7 @@ while :; do
 		?" ${msg_exit}") break ;;
 		?" ${msg_add_new_nic}")
 			last_nic=$( find_first_free_nic_id )
-			nic="nic${last_nic}"
+			nic="eth${last_nic}"
 			command="jailnic-newnic jname=${jname} nic=${nic} out=${mysqlite}"
 			;;
 		*)

--- a/share/bsdconfig/cbsd/jailnic-cfgnic
+++ b/share/bsdconfig/cbsd/jailnic-cfgnic
@@ -118,7 +118,7 @@ else
 		# create new database when jail/db not exist
 		if [ ! -r ${mysqlite} ]; then
 			/usr/local/bin/cbsd ${miscdir}/updatesql ${mysqlite} ${CIX_DISTDIR}/share/local-jailnic.schema jailnic
-			cbsdsqlrw ${mysqlite} "INSERT INTO jailnic ( name,nic_order,nic_slot,nic_parent,nic_hwaddr,nic_address,nic_mtu,nic_flags,nic_vlan_untagged,nic_vlan_tagged ) VALUES ( 'epairb','0','0','auto','${nic_hwaddr}','${nic_address}','0','0','0','0' )"
+			cbsdsqlrw ${mysqlite} "INSERT INTO jailnic ( name,nic_order,nic_slot,nic_parent,nic_hwaddr,nic_address,nic_mtu,nic_flags,nic_vlan_untagged,nic_vlan_tagged ) VALUES ( 'eth0','0','0','auto','${nic_hwaddr}','${nic_address}','0','0','0','0' )"
 		fi
 	fi
 fi

--- a/share/bsdconfig/cbsd/jailnic-newnic
+++ b/share/bsdconfig/cbsd/jailnic-newnic
@@ -83,7 +83,7 @@ else
 		# create new database when jail/db not exist
 		if [ ! -r ${mysqlite} ]; then
 			/usr/local/bin/cbsd ${miscdir}/updatesql ${mysqlite} ${CIX_DISTDIR}/share/local-jailnic.schema jailnic
-			cbsdsqlrw ${mysqlite} "INSERT INTO jailnic ( name,nic_order,nic_slot,nic_parent,nic_hwaddr,nic_address,nic_mtu,nic_flags,nic_vlan_untagged,nic_vlan_tagged ) VALUES ( 'epairb','0','0','auto','${nic_hwaddr}','${nic_address}','0','0','0','0' )"
+			cbsdsqlrw ${mysqlite} "INSERT INTO jailnic ( name,nic_order,nic_slot,nic_parent,nic_hwaddr,nic_address,nic_mtu,nic_flags,nic_vlan_untagged,nic_vlan_tagged ) VALUES ( 'eth0','0','0','auto','${nic_hwaddr}','${nic_address}','0','0','0','0' )"
 		fi
 	fi
 fi
@@ -117,7 +117,7 @@ f_dialog_backtitle "${ipgm:+bsdconfig }$pgm"
 f_mustberoot_init
 
 last_nic=$( find_first_free_nic_id )
-nic_name="nic${last_nic}"
+nic_name="eth${last_nic}"
 
 #
 # Loop over the main menu until we've accomplished what we came here to do

--- a/subr/vnet.subr
+++ b/subr/vnet.subr
@@ -369,7 +369,7 @@ get_my_epair()
 
 	if [ -z "${macb}" -o "${macb}" = "0" ]; then
 		macb=$( mac_gen 02:ff:f0 )
-		cbsdsqlrw ${jailsysdir}/${jname}/local.sqlite "INSERT INTO jailnic ( name,nic_order,nic_slot,nic_parent,nic_hwaddr,nic_mtu,nic_flags,nic_vlan_untagged,nic_vlan_tagged ) VALUES ( 'epairb','0','0','auto','${macb}','0','0','0','0' )"
+		cbsdsqlrw ${jailsysdir}/${jname}/local.sqlite "INSERT INTO jailnic ( name,nic_order,nic_slot,nic_parent,nic_hwaddr,nic_mtu,nic_flags,nic_vlan_untagged,nic_vlan_tagged ) VALUES ( 'eth0','0','0','auto','${macb}','0','0','0','0' )"
 	fi
 
 	# flush stdout

--- a/sudoexec/jcreate
+++ b/sudoexec/jcreate
@@ -949,7 +949,7 @@ else
 			cbsdsqlrw ${jailsysdir}/${jname}/local.sqlite "INSERT INTO jailnic ( name,nic_order,nic_slot,nic_parent,nic_mtu,nic_flags,nic_vlan_untagged,nic_vlan_tagged ) VALUES ( '${tmp_iface}','0','0','auto','0','0','0','0' )"
 			;;
 		*)
-			cbsdsqlrw ${jailsysdir}/${jname}/local.sqlite "INSERT INTO jailnic ( name,nic_order,nic_slot,nic_parent,nic_mtu,nic_flags,nic_vlan_untagged,nic_vlan_tagged ) VALUES ( 'epairb','0','0','auto','0','0','0','0' )"
+			cbsdsqlrw ${jailsysdir}/${jname}/local.sqlite "INSERT INTO jailnic ( name,nic_order,nic_slot,nic_parent,nic_mtu,nic_flags,nic_vlan_untagged,nic_vlan_tagged ) VALUES ( 'eth0','0','0','auto','0','0','0','0' )"
 			;;
 	esac
 

--- a/sudoexec/jstart
+++ b/sudoexec/jstart
@@ -552,6 +552,8 @@ fi
 epairb_list=
 # for traffic count
 epaira_list=
+# NIC names from DB (for interface renaming inside jail)
+nic_name_list=
 
 # extract and export/rewrite interface variable from jailnic for vnet-based jails
 if [ "${vnet}" = "1" ]; then
@@ -562,10 +564,9 @@ if [ "${vnet}" = "1" ]; then
 		printf "${_int} "
 	done ) || err 1 "${N1_COLOR}jstart: error get interfaces name for vnet nic map${N0_COLOR}"
 
-	eth_seq=0
-	printf "${N1_COLOR}create epair: "
 
 	for i in ${interfaces}; do
+		printf "${N1_COLOR}create nic: ${i}${N0_COLOR} "
 		nic_hwaddr=
 		nic_parent=
 		nic_address=
@@ -647,8 +648,6 @@ if [ "${vnet}" = "1" ]; then
 				fi
 		esac
 
-		echo "NT: ${nic_type}"
-
 		if [ "${nic_type}" = "ppt" ]; then
 			myepair="${i}"
 			if [ -z "${epairb_list}" ]; then
@@ -662,9 +661,11 @@ if [ "${vnet}" = "1" ]; then
 			if [ -z "${epairb_list}" ]; then
 				epaira_list="${myepair}a"
 				epairb_list="${myepair}b"
+				nic_name_list="${i}"
 			else
 				epaira_list="${epaira_list},${myepair}a"
 				epairb_list="${epairb_list},${myepair}b"
+				nic_name_list="${nic_name_list},${i}"
 			fi
 		fi
 
@@ -695,19 +696,18 @@ if [ "${vnet}" = "1" ]; then
 		[ -n "${nic_mtu}" -a "${nic_mtu}" != "0" ] && _extra_info="${_extra_info} mtu:${nic_mtu}"
 		[ -n "${nic_flags}" -a "${nic_flags}" != "0" ] && _extra_info="${_extra_info} flags:${nic_flags}"
 
-		printf "${H3_COLOR}${myepair}(type:${nic_type}):${N2_COLOR}${nic_parent}${_extra_info}"
+		printf "${H3_COLOR}${myepair}(type:${nic_type}):${N2_COLOR}${nic_parent}${_extra_info}\n"
 
 		case "${nic_type}" in
 			ppt)
-				#${IFCONFIG_CMD} ${myepair} description ${jname}-eth${eth_seq} up
 				${IFCONFIG_CMD} ${myepair} description ${jname}-${myepair} up
 				;;
 			*)
-				${IFCONFIG_CMD} ${myepair}a description ${jname}-eth${eth_seq} up
+				# Use NIC name from DB (${i}) for description
+				${IFCONFIG_CMD} ${myepair}a description ${jname}-${i} up
 				;;
 		esac
 
-		eth_seq=$(( eth_seq + 1 ))
 
 		case "${nic_type}" in
 			ppt)
@@ -1017,50 +1017,55 @@ fi
 if [ ${vnet} -eq 1 ]; then
 	OIFS="${IFS}"
 	IFS=","
-	eth_seq=0
+	_nic_idx=1
 	int_iface=
 	for i in ${epairb_list}; do
 		[ -z "${i}" ] && continue
 		IFS="${OIFS}"
 		${IFCONFIG_CMD} ${i} up
-		# we need setup lock here due to ethX name possible conflict with other jail
+
+		# Get NIC name from nic_name_list (parallel list)
+		_target_nic_name=$( echo "${nic_name_list}" | ${CUT_CMD} -d',' -f${_nic_idx} )
+		[ -z "${_target_nic_name}" ] && _target_nic_name="eth$(( _nic_idx - 1 ))"
+
+		# we need setup lock here due to interface name possible conflict with other jail
 		_wait_count=0
 		[ -z "${_iface_rename}" ] && _iface_rename=0
 
 		if [ ${_iface_rename} -eq 1 ]; then
-			while [ -r ${tmpdir}/eth${eth_seq}.locked ]; do
+			while [ -r ${tmpdir}/${_target_nic_name}.locked ]; do
 				_cur_time=$( ${DATE_CMD} +%s )
-				eval $( ${STAT_CMD} -s ${tmpdir}/eth${eth_seq}.locked )
+				eval $( ${STAT_CMD} -s ${tmpdir}/${_target_nic_name}.locked )
 				_diff_time=$(( _cur_time - st_mtime ))
 
 				if [ ${_diff_time} -gt 8 ]; then
-					${IFCONFIG_CMD} eth${eth_seq} > /dev/null 2>&1
+					${IFCONFIG_CMD} ${_target_nic_name} > /dev/null 2>&1
 					_ret=$?
 					if [ ${_ret} -ne 0 ]; then
 						# remove orphaned lock
-						${RM_CMD} -f ${tmpdir}/eth${eth_seq}.locked
+						${RM_CMD} -f ${tmpdir}/${_target_nic_name}.locked
 						break
 					fi
 				fi
 
-				[ ${quiet} -ne 1 ] && ${ECHO} "${N1_COLOR}jstart: eth${eth_seq} locked (${_diff_time}), waiting (${_wait_count}/12)..${N0_COLOR}"
+				[ ${quiet} -ne 1 ] && ${ECHO} "${N1_COLOR}jstart: ${_target_nic_name} locked (${_diff_time}), waiting (${_wait_count}/12)..${N0_COLOR}"
 
 				_wait_count=$(( _wait_count + 1 ))
 
 				if [ ${_wait_count} -gt 12 ]; then
-					_res=$( ${CAT_CMD} ${tmpdir}/eth${eth_seq}.locked )
+					_res=$( ${CAT_CMD} ${tmpdir}/${_target_nic_name}.locked )
 					jstop jname=${jname} fast=1
 					${IFCONFIG_CMD} ${i} destroy
-					log_err 1 "${N1_COLOR}${CIX_APP}: waiting for unlock: still locked by [${_res}]: ${N2_COLOR}${tmpdir}/eth${eth_seq}.locked${N0_COLOR}"
+					log_err 1 "${N1_COLOR}${CIX_APP}: waiting for unlock: still locked by [${_res}]: ${N2_COLOR}${tmpdir}/${_target_nic_name}.locked${N0_COLOR}"
 				fi
 
 				sleep 1
 			done
 
 			# make lock
-			echo "${jname}" > ${tmpdir}/eth${eth_seq}.locked
-			${IFCONFIG_CMD} ${i} name eth${eth_seq} && ${IFCONFIG_CMD} eth${eth_seq} vnet ${jname}
-			int_iface="eth${eth_seq}"
+			echo "${jname}" > ${tmpdir}/${_target_nic_name}.locked
+			${IFCONFIG_CMD} ${i} name ${_target_nic_name} && ${IFCONFIG_CMD} ${_target_nic_name} vnet ${jname}
+			int_iface="${_target_nic_name}"
 		else
 			${IFCONFIG_CMD} ${i} vnet ${jname}
 			int_iface="${i}"
@@ -1221,8 +1226,8 @@ if [ ${vnet} -eq 1 ]; then
 		done
 
 		# release lock
-		[ -r ${tmpdir}/eth${eth_seq}.locked ] && ${RM_CMD} -f ${tmpdir}/eth${eth_seq}.locked
-		eth_seq=$(( eth_seq + 1 ))
+		[ -r ${tmpdir}/${_target_nic_name}.locked ] && ${RM_CMD} -f ${tmpdir}/${_target_nic_name}.locked
+		_nic_idx=$(( _nic_idx + 1 ))
 		IFS=","
 	done
 

--- a/upgrade/pre-patch-15.0.1.2
+++ b/upgrade/pre-patch-15.0.1.2
@@ -1,0 +1,34 @@
+#!/bin/sh
+#v15.0.1
+# Rename epairb -> eth0 in jailnic tables
+[ -z "${CIX_DISTDIR}" ] && CIX_DISTDIR="/usr/local/cbsd"
+[ ! -r "${CIX_DISTDIR}/subr/cbsdbootstrap.subr" ] && exit 1
+. ${CIX_DISTDIR}/subr/cbsdbootstrap.subr || exit 1
+test_sql_stuff
+
+[ ! -h "${dbdir}/local.sqlite" ] && exit 0
+
+mydb="${dbdir}/local.sqlite"
+
+_count=$( ${miscdir}/sqlcli ${mydb} "SELECT COUNT(jname) FROM jails WHERE emulator='jail'" )
+[ "${_count}" = "0" ] && exit 0
+
+jls=$( ${miscdir}/sqlcli ${mydb} "SELECT jname FROM jails WHERE emulator = 'jail'" )
+
+for jname in ${jls}; do
+	jaildb="${jailsysdir}/${jname}/local.sqlite"
+	[ ! -r "${jaildb}" ] && continue
+
+	# Check if jailnic table exists
+	_table_exists=$( ${miscdir}/sqlcli ${jaildb} "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='jailnic';" )
+	[ "${_table_exists}" = "0" ] && continue
+
+	# Rename epairb -> eth0
+	_has_epairb=$( ${miscdir}/sqlcli ${jaildb} "SELECT COUNT(*) FROM jailnic WHERE name='epairb';" )
+	if [ "${_has_epairb}" != "0" ]; then
+		${ECHO} "  * ${N1_COLOR}Update ${jname} jailnic: rename epairb -> eth0${N0_COLOR}"
+		${miscdir}/sqlcli ${jaildb} "UPDATE jailnic SET name='eth0' WHERE name='epairb'"
+	fi
+done
+
+exit 0


### PR DESCRIPTION
New CLI command jailnic:
- cbsd jailnic <jail> list - display NIC configuration
- cbsd jailnic <jail> add - add new NIC with auto-assigned slot/name
- cbsd jailnic <jail> update <name> - modify NIC parameters
- cbsd jailnic <jail> delete <name> - remove NIC

- Supports both positional args and key=value syntax
- Supports NIC rename via: jailnic <jail> update <old> name=<new>
- Warns when jail is running that jrestart is required

NIC naming changes:
- Save actual interface name into database (before was hardcoded as eth0/nic1/...)
- Default NIC name changed from 'epairb' to 'eth0' in DB
- Additional NICs use eth0, eth1, ... instead of nic1, nic2, ...
- If custom name used - it will be visibel in jail
- Host-side epair description shows <jail>-<nic-name>

jstart changes:
- Added nic_name_list to track NIC names from DB parallel to epairb_list
- Interface renaming inside jail now uses name from DB instead hardcoded ethX

TUI/schema fixes:
- find_first_free_nic_id() now starts from 0 (was 1)
- add_nic() finds next free slot before INSERT
- Updated default NIC name in jailnic, jailnic-newnic, jailnic-cfgnic

Migration (upgrade/pre-patch-15.0.1.2):
- Renames 'epairb' to 'eth0' in existing jailnic tables