### PR TITLE
Fix: jailnic CLI now correctly handles update of 'interface' parameter

### DIFF
--- a/jailctl/jailnic
+++ b/jailctl/jailnic
@@ -112,14 +112,16 @@ fi
 # Validate jname
 [ -z "${jname}" ] && err 1 "${N1_COLOR}jailnic: ${N2_COLOR}jname=${N1_COLOR} is required. Use ${N2_COLOR}help${N1_COLOR} for usage.${N0_COLOR}"
 
-# Save 'name' before rcconf.subr (it unsets columns from local-jails.schema including 'name')
+# Save variables before rcconf.subr (it unsets columns from local-jails.schema)
 _saved_nic_name="${name}"
+_saved_interface="${interface}"
 
 . ${subrdir}/rcconf.subr
 [ $? -eq 1 ] && err 1 "${N1_COLOR}jailnic: no such jail: ${N2_COLOR}${jname}${N0_COLOR}"
 
-# Restore 'name' after rcconf.subr
+# Restore variables after rcconf.subr
 name="${_saved_nic_name}"
+interface="${_saved_interface}"
 [ "${emulator}" != "jail" ] && err 1 "${N1_COLOR}jailnic: ${N2_COLOR}${jname}${N1_COLOR} is not a jail (emulator=${emulator})${N0_COLOR}"
 
 mysqlite="${jailsysdir}/${jname}/local.sqlite"


### PR DESCRIPTION
The 'interface' variable was being reset by rcconf.subr (which unsets all columns from local-jails.schema before loading jail config). Added save/restore for 'interface' alongside existing 'name' variable preservation.

Affected: jailctl/jailnic