### PR TITLE
Do not raise warning when jset the same shared IP address

### DIFF
--- a/jailctl/jset
+++ b/jailctl/jset
@@ -86,7 +86,7 @@ validate_ipaddr()
 	_i=0
 	OIFS="${IFS}"
 	IFS="|"
-	eval $( cbsdsqlro local "SELECT jname,ip4_addr FROM jails WHERE ip4_addr!='0'" 2>/dev/null | while read _jname _ips; do
+	eval $( cbsdsqlro local "SELECT jname,ip4_addr FROM jails WHERE ip4_addr!='0' AND vnet!='0'" 2>/dev/null | while read _jname _ips; do
 		IFS="${OIFS}"
 		echo jname${_i}=\"$_jname\"
 		echo ips${_i}=\"${_ips}\"

--- a/jailctl/jset
+++ b/jailctl/jset
@@ -86,7 +86,11 @@ validate_ipaddr()
 	_i=0
 	OIFS="${IFS}"
 	IFS="|"
-	eval $( cbsdsqlro local "SELECT jname,ip4_addr FROM jails WHERE ip4_addr!='0' AND vnet!='0'" 2>/dev/null | while read _jname _ips; do
+
+	myvnet=$( cbsdsqlro local "SELECT vnet FROM jails WHERE jname='${jname}'" )
+	[ "${myvnet}" = "0" ] && vnet_clause="AND vnet!='0'"
+
+	eval $( cbsdsqlro local "SELECT jname,ip4_addr FROM jails WHERE ip4_addr!='0' ${vnet_clause}" 2>/dev/null | while read _jname _ips; do
 		IFS="${OIFS}"
 		echo jname${_i}=\"$_jname\"
 		echo ips${_i}=\"${_ips}\"


### PR DESCRIPTION
fix the issue - 192.168.9.14 is the host address used as shared for vnet=0

```shell
host# cbsd jcreate jname=fbsd1 ver=15.0 vnet=0 interface=0 ip4_addr=192.168.9.144 ...
host# cbsd jset jname=fbsd1 ip4_addr=192.168.9.14
jset warning: IP address 192.168.9.14 already assigned to jail: grafana 
jset warning: IP address 192.168.9.14 already assigned to jail: prom 
jset warning: IP address 192.168.9.14 already assigned to jail: site 
host#
```

Root cause - when we check duplicate IPs we consider all jails, including vnet=0 jails, which should have shared IPs by design.

Fix - exclude vnet=0 jails from duplicates lookup