### PR TITLE
Workaround missed allow_zfs while jail restart

### DIFF
--- a/subr/system.subr
+++ b/subr/system.subr
@@ -358,6 +358,7 @@ mount_jail_fstab()
 		_mypath=${data}
 	fi
 
+	export allow_zfs
 	if [ -r ${mount_fstab} ]; then
 		_res=$( mountfstab jroot=${_mypath} fstab=${mount_fstab} jname="${jname}" )
 


### PR DESCRIPTION
problem:

host# cbsd jstart backup
/usr/local/cbsd/tools/mountfstab: 154: [: -ne: unexpected operator /usr/local/cbsd/tools/mountfstab: 228: [: -ne: unexpected operator persist mode: on
set resource limit: [ ]
...
host# cbsd jget jname=backup allow_zfs
allow_zfs: 1
host#

Proposed fix bypass the value of allow_zfs from jstart but, it will not work for standalone start of mountfstab even more not really clear where to get allow_zfs if only root and fstab file are passed