### PR TITLE
Fix jname calculation in cbsd up

### DIFF
--- a/subr/up.subr
+++ b/subr/up.subr
@@ -331,10 +331,10 @@ run_jail()
 		return ${_ret}
 	fi
 
+	ojname="${jname}"
+
 	. ${subrdir}/rcconf.subr
 	[ $? -eq 0 ] && err 1 "${N1_COLOR}already exist: ${N2_COLOR}${jname}${N0_COLOR}"
-
-	ojname="${jname}"
 
 	# push old cbsd workdir
 	ocbsd_workdir="${workdir}"


### PR DESCRIPTION
Fix jname calculation in cbsd up - it was improperly reset by rcconf.subr and did not restored