### PR TITLE
Add JQ-based variable expansion

### DIFF
--- a/bin/cbsdsh/build
+++ b/bin/cbsdsh/build
@@ -21,7 +21,7 @@ case "${PLATFORM}" in
 		export LDFLAGS="-L/usr/lib"
 		export LD_LIBRARY_PATH="/usr/lib"
 		export C_INCLUDE_PATH="/usr/include"
-		export CONFIGURE_ARGS="--with-libsqlite3"
+        export CONFIGURE_ARGS="--with-libsqlite3 --with-libjq"
 		;;
 	FreeBSD)
 		MAKE_CMD=$( which gmake )
@@ -29,7 +29,7 @@ case "${PLATFORM}" in
 		export LDFLAGS="-L/usr/lib -L/usr/local/lib"
 		export LD_LIBRARY_PATH="/usr/lib /usr/local/lib"
 		export C_INCLUDE_PATH="/usr/include /usr/local/include"
-		export CONFIGURE_ARGS="--with-libsqlite3 --with-libjail"
+		export CONFIGURE_ARGS="--with-libsqlite3 --with-libjail --with-libjq"
 		;;
 	*)
 		MAKE_CMD="make"

--- a/bin/cbsdsh/config.h.in
+++ b/bin/cbsdsh/config.h.in
@@ -40,6 +40,9 @@
 /* Define to 1 if you have the 'killpg' function. */
 #undef HAVE_KILLPG
 
+/* Define if building with libjq support */
+#undef HAVE_LIBJQ
+
 /* Define to 1 if you have the 'memfd_create' function. */
 #undef HAVE_MEMFD_CREATE
 

--- a/bin/cbsdsh/configure.ac
+++ b/bin/cbsdsh/configure.ac
@@ -248,6 +248,28 @@ else
 fi
 AM_CONDITIONAL([USE_LIBJAIL], [test "$use_libjail" = "yes"])
 
+AC_ARG_WITH(libjq, AS_HELP_STRING(--with-libjq, [Compile with libjq (jq) support]))
+use_libjq=
+if test "$with_libjq" = "yes"; then
+	AC_CHECK_LIB(jq, jq_init, [
+		AC_CHECK_HEADER([jq.h], [
+			AC_CHECK_HEADER([jv.h], [use_libjq="yes"],
+				AC_MSG_ERROR([Can't find required jv.h header.]))
+		], AC_MSG_ERROR([Can't find required jq.h header.]))
+	], [
+		AC_MSG_ERROR([Can't find libjq.])
+	])
+fi
+
+if test "$use_libjq" != "yes"; then
+	AC_DEFINE([SMALL], 1, [Define if you build with -DSMALL])
+else
+	AC_DEFINE([HAVE_LIBJQ], 1, [Define if building with libjq support])
+	AC_CHECK_LIB(onig, onig_version, [export LIBS="$LIBS -lonig"], :)
+	export LIBS="$LIBS -ljq"
+fi
+AM_CONDITIONAL([USE_LIBJQ], [test "$use_libjq" = "yes"])
+
 export LIBS="$LIBS -pthread"
 
 dnl Detect platform for cbsd_fwatch (use CBSD_PLATFORM from build script if set)

--- a/bin/cbsdsh/src/Makefile.am
+++ b/bin/cbsdsh/src/Makefile.am
@@ -21,7 +21,7 @@ dash_CFILES = \
 	histedit.c input.c jobs.c mail.c main.c memalloc.c miscbltin.c \
 	mystring.c options.c parser.c redir.c show.c trap.c output.c \
 	bltin/printf.c system.c bltin/test.c bltin/times.c var.c about.c spawn_task.c \
-	sqlcmd.c logger.c
+	sqlcmd.c jqcmd.c logger.c
 
 if USE_FWATCH_LINUX
 dash_CFILES += cbsd_fwatch_linux.c

--- a/bin/cbsdsh/src/builtins.def.in
+++ b/bin/cbsdsh/src/builtins.def.in
@@ -97,6 +97,8 @@ killcmd		-u kill
 sqlitecmdro	cbsdsqlro
 sqlitecmdrw	cbsdsqlrw
 sqlitecmdro_vars	cbsdsqlro_vars
+sqlitecmdquery	cbsdsqlquery
+jqcmd		jq
 aboutcmd	about
 is_numbercmd	is_number
 substrcmd	substr

--- a/bin/cbsdsh/src/expand.c
+++ b/bin/cbsdsh/src/expand.c
@@ -1618,7 +1618,9 @@ static void *opendir_interruptible(const char *pathname)
 	return opendir(pathname);
 }
 #else
+#ifndef GLOB_ALTDIRFUNC
 #define GLOB_ALTDIRFUNC 0
+#endif
 #endif
 
 static void expandmeta_glob(struct strlist *str)

--- a/bin/cbsdsh/src/expand.c
+++ b/bin/cbsdsh/src/expand.c
@@ -784,12 +784,13 @@ out:
  *  - malloc()'d C string (caller must free), or NULL on hard failure.
  *  - If jq produces no output, returns strdup("") with ok=1.
  */
- static char *
- jq_eval_once(const char *json, const char *filter, int *ok)
+static char *
+jq_eval_once(const char *json, const char *filter, int *ok)
 {
 	jq_state *jq = NULL;
 	jv input, out, dumped;
 	char *ret = NULL;
+	size_t retlen = 0;
 
 	if (ok) *ok = 0;
 	if (json == NULL) json = "";
@@ -812,52 +813,68 @@ out:
 	}
 
 	jq_start(jq, input, 0);
+	dumped = jv_invalid();
 
-	out = jq_next(jq);
+	for (;;) {
+		out = jq_next(jq);
 
-	/* No output is not an error for our purposes */
-	if (!jv_is_valid(out)) {
-		/* out is invalid sentinel; free it to be safe */
+		/* No output is not an error for our purposes */
+		if (!jv_is_valid(out)) {
+			/* out is invalid sentinel; free it to be safe */
+			jv_free(out);
+			break;
+		}
+
+		const char *chunk = NULL;
+		switch (jv_get_kind(out)) {
+		case JV_KIND_STRING:
+			/* raw string (no quotes) */
+			chunk = jv_string_value(out);
+			break;
+
+		case JV_KIND_NUMBER:
+		case JV_KIND_TRUE:
+		case JV_KIND_FALSE:
+		case JV_KIND_NULL:
+		case JV_KIND_ARRAY:
+		case JV_KIND_OBJECT:
+		default:
+			/* dump JSON for non-strings */
+			dumped = jv_dump_string(out, 0);
+			chunk = jv_string_value(dumped);
+			break;
+		}
+
+		if (chunk) {
+			size_t clen = strlen(chunk);
+			size_t need = retlen + clen + (retlen ? 1 : 0) + 1;
+			char *nret = realloc(ret, need);
+			if (nret == NULL) {
+				if (jv_is_valid(dumped))
+					jv_free(dumped);
+				jv_free(out);
+				free(ret);
+				jq_teardown(&jq);
+				return NULL;
+			}
+			ret = nret;
+			if (retlen) {
+				ret[retlen] = '\n';
+				retlen++;
+			}
+			memcpy(ret + retlen, chunk, clen);
+			retlen += clen;
+			ret[retlen] = '\0';
+		}
+
+		if (jv_is_valid(dumped))
+			jv_free(dumped);
+		dumped = jv_invalid();
 		jv_free(out);
+	}
+
+	if (ret == NULL)
 		ret = strdup("");
-		if (ret != NULL && ok) *ok = 1;
-		jq_teardown(&jq);
-		return ret;
-	}
-
-	switch (jv_get_kind(out)) {
-	case JV_KIND_STRING:
-		/* raw string (no quotes) */
-		ret = strdup(jv_string_value(out));
-		break;
-
-	case JV_KIND_NUMBER:
-	case JV_KIND_TRUE:
-	case JV_KIND_FALSE:
-	case JV_KIND_NULL:
-		/* scalars: dump as text (already raw-ish) */
-		dumped = jv_dump_string(out, 0);
-		ret = strdup(jv_string_value(dumped));
-		jv_free(dumped);
-		break;
-
-	case JV_KIND_ARRAY:
-	case JV_KIND_OBJECT:
-		/* structured: dump JSON */
-		dumped = jv_dump_string(out, 0); /* or JV_PRINT_PRETTY if you want */
-		ret = strdup(jv_string_value(dumped));
-		jv_free(dumped);
-		break;
-
-	default:
-		/* should not happen, but be safe */
-		dumped = jv_dump_string(out, 0);
-		ret = strdup(jv_string_value(dumped));
-		jv_free(dumped);
-		break;
-	}
-
-	jv_free(out);
 	jq_teardown(&jq);
 
 	if (ret != NULL && ok) *ok = 1;

--- a/bin/cbsdsh/src/expand.c
+++ b/bin/cbsdsh/src/expand.c
@@ -57,6 +57,9 @@
 #include <wchar.h>
 #include <wctype.h>
 
+#include <jq.h>
+#include <jv.h>
+
 /*
  * Routines to expand arguments to commands.  We have to deal with
  * backquotes, shell variables, and file metacharacters.
@@ -772,6 +775,96 @@ out:
 
 
 /*
+ * jq_eval_once()
+ *  - json:   input JSON text
+ *  - filter: jq program (e.g. ".name.value")
+ *  - ok:     set to 1 on success, 0 on failure
+ *
+ * Returns:
+ *  - malloc()'d C string (caller must free), or NULL on hard failure.
+ *  - If jq produces no output, returns strdup("") with ok=1.
+ */
+ static char *
+ jq_eval_once(const char *json, const char *filter, int *ok)
+{
+	jq_state *jq = NULL;
+	jv input, out, dumped;
+	char *ret = NULL;
+
+	if (ok) *ok = 0;
+	if (json == NULL) json = "";
+	if (filter == NULL) return NULL;
+
+	jq = jq_init();
+	if (jq == NULL)
+		return NULL;
+
+	if (!jq_compile(jq, filter)) {
+		jq_teardown(&jq);
+		return NULL;
+	}
+
+	input = jv_parse(json);
+	if (!jv_is_valid(input)) {
+		jv_free(input);
+		jq_teardown(&jq);
+		return NULL;
+	}
+
+	jq_start(jq, input, 0);
+
+	out = jq_next(jq);
+
+	/* No output is not an error for our purposes */
+	if (!jv_is_valid(out)) {
+		/* out is invalid sentinel; free it to be safe */
+		jv_free(out);
+		ret = strdup("");
+		if (ret != NULL && ok) *ok = 1;
+		jq_teardown(&jq);
+		return ret;
+	}
+
+	switch (jv_get_kind(out)) {
+	case JV_KIND_STRING:
+		/* raw string (no quotes) */
+		ret = strdup(jv_string_value(out));
+		break;
+
+	case JV_KIND_NUMBER:
+	case JV_KIND_TRUE:
+	case JV_KIND_FALSE:
+	case JV_KIND_NULL:
+		/* scalars: dump as text (already raw-ish) */
+		dumped = jv_dump_string(out, 0);
+		ret = strdup(jv_string_value(dumped));
+		jv_free(dumped);
+		break;
+
+	case JV_KIND_ARRAY:
+	case JV_KIND_OBJECT:
+		/* structured: dump JSON */
+		dumped = jv_dump_string(out, 0); /* or JV_PRINT_PRETTY if you want */
+		ret = strdup(jv_string_value(dumped));
+		jv_free(dumped);
+		break;
+
+	default:
+		/* should not happen, but be safe */
+		dumped = jv_dump_string(out, 0);
+		ret = strdup(jv_string_value(dumped));
+		jv_free(dumped);
+		break;
+	}
+
+	jv_free(out);
+	jq_teardown(&jq);
+
+	if (ret != NULL && ok) *ok = 1;
+	return ret;
+}
+
+/*
  * Expand a variable, and return a pointer to the next character in the
  * input string.
  */
@@ -806,8 +899,10 @@ evalvar(char *p, int flag)
 		break;
 	}
 
+	int novalue = 0;
 again:
-	varlen = varvalue(var, varflags, flag | mbchar);
+	novalue = (subtype == VSJQEXPR) ? EXP_DISCARD : 0;
+	varlen = varvalue(var, varflags, flag | mbchar | novalue);
 	if (varflags & VSNUL)
 		varlen--;
 
@@ -822,6 +917,42 @@ again:
 	case VSMINUS:
 		p = argstr(p, flag | EXP_TILDE | EXP_WORD |
 			      (discard ^ EXP_DISCARD));
+		goto record;
+
+		case VSJQEXPR: {
+			/* remember start offset in stack */
+			ptrdiff_t start = expdest - (char *)stackblock();
+
+			/* parse jq expression into expdest */
+			p = argstr(p, flag);
+
+			/* refresh base after argstr (stack may have moved) */
+			char *base = (char *)stackblock();
+			char *jqexpr = base + start;
+
+			/* NUL-terminate expression */
+			STPUTC('\0', expdest);
+			rmescapes(jqexpr);
+
+			if (!(flag & EXP_DISCARD)) {
+				const char *val = lookupvar(var);
+				if (val == NULL) val = "";
+
+				int ok = 0;
+				char *result = jq_eval_once(val, jqexpr, &ok);
+
+				/* rollback expdest so jqexpr doesn't appear in output */
+				STADJUST((int)(start - (expdest - base)), expdest);
+
+				if (ok && result)
+					memtodest(result, strlen(result), flag);
+
+				free(result);
+			} else {
+				/* rollback even if discarding output */
+				STADJUST((int)(start - (expdest - base)), expdest);
+			}
+		}
 		goto record;
 
 	case VSASSIGN:
@@ -1470,9 +1601,7 @@ static void *opendir_interruptible(const char *pathname)
 	return opendir(pathname);
 }
 #else
-#ifndef GLOB_ALTDIRFUNC
 #define GLOB_ALTDIRFUNC 0
-#endif
 #endif
 
 static void expandmeta_glob(struct strlist *str)

--- a/bin/cbsdsh/src/jqcmd.c
+++ b/bin/cbsdsh/src/jqcmd.c
@@ -610,6 +610,7 @@ out:
 	jv_free(program_arguments);
 	jq_util_input_free(&input_state);
 	jq_teardown(&jq);
+	fflush(stdout);
 
 	if (options & JQ_OPT_EXIT_STATUS) {
 		if (ret != JQ_OK_NO_OUTPUT)

--- a/bin/cbsdsh/src/jqcmd.c
+++ b/bin/cbsdsh/src/jqcmd.c
@@ -1,0 +1,628 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <ctype.h>
+#include <string.h>
+#include <errno.h>
+#include <unistd.h>
+
+#include "shell.h"
+#include "builtins.h"
+
+#include <jq.h>
+#include <jv.h>
+
+enum {
+	JQ_OPT_SLURP = 1,
+	JQ_OPT_RAW_INPUT = 2,
+	JQ_OPT_PROVIDE_NULL = 4,
+	JQ_OPT_RAW_OUTPUT = 8,
+	JQ_OPT_RAW_OUTPUT0 = 16,
+	JQ_OPT_ASCII_OUTPUT = 32,
+	JQ_OPT_COLOR_OUTPUT = 64,
+	JQ_OPT_NO_COLOR_OUTPUT = 128,
+	JQ_OPT_SORTED_OUTPUT = 256,
+	JQ_OPT_FROM_FILE = 512,
+	JQ_OPT_RAW_NO_LF = 1024,
+	JQ_OPT_UNBUFFERED = 2048,
+	JQ_OPT_EXIT_STATUS = 4096,
+	JQ_OPT_SEQ = 8192
+};
+
+enum {
+	JQ_OK = 0,
+	JQ_OK_NULL_KIND = -1,
+	JQ_ERROR_SYSTEM = 2,
+	JQ_ERROR_COMPILE = 3,
+	JQ_OK_NO_OUTPUT = -4,
+	JQ_ERROR_UNKNOWN = 5
+};
+
+static void
+jq_usage_short(void)
+{
+	fprintf(stderr,
+	    "usage: jq [options] <filter> [file...]\n"
+	    "       jq [options] -f <file> [file...]\n"
+	    "       jq [options] --args [strings...]\n"
+	    "       jq [options] --jsonargs [JSON_TEXTS...]\n");
+}
+
+static int
+jq_isoptish(const char *text)
+{
+	return text[0] == '-' &&
+	    (text[1] == '-' || isalpha((unsigned char)text[1]));
+}
+
+static int
+jq_isoption(const char **text, char shortopt, const char *longopt,
+    int is_short)
+{
+	if (is_short) {
+		if (shortopt && **text == shortopt) {
+			(*text)++;
+			if (!**text)
+				*text = NULL;
+			return 1;
+		}
+	} else {
+		if (!strcmp(*text, longopt)) {
+			*text = NULL;
+			return 1;
+		}
+	}
+	return 0;
+}
+
+static int
+jq_append_program(char **program, size_t *program_len, const char *chunk,
+    size_t chunk_len)
+{
+	size_t new_len = *program_len + chunk_len + 1;
+	char *next = realloc(*program, new_len + 1);
+
+	if (next == NULL)
+		return 0;
+	memcpy(next + *program_len, chunk, chunk_len);
+	next[new_len - 1] = '\n';
+	next[new_len] = '\0';
+	*program = next;
+	*program_len = new_len;
+	return 1;
+}
+
+static int
+jq_process(jq_state *jq, jv value, int jq_flags, int dumpopts, int options)
+{
+	int ret = JQ_OK_NO_OUTPUT;
+
+	jq_start(jq, value, jq_flags);
+	for (;;) {
+		jv result = jq_next(jq);
+		if (!jv_is_valid(result)) {
+			if (jv_invalid_has_msg(jv_copy(result))) {
+				jv msg = jv_invalid_get_msg(jv_copy(result));
+				jv input_pos = jq_util_input_get_position(jq);
+				fprintf(stderr, "jq: error (at %s): %s\n",
+				    jv_string_value(input_pos),
+				    jv_string_value(msg));
+				jv_free(input_pos);
+				jv_free(msg);
+				ret = JQ_ERROR_UNKNOWN;
+			}
+			jv_free(result);
+			break;
+		}
+
+		if ((options & JQ_OPT_RAW_OUTPUT) &&
+		    jv_get_kind(result) == JV_KIND_STRING) {
+			if (options & JQ_OPT_ASCII_OUTPUT) {
+				jv_dumpf(jv_copy(result), stdout,
+				    JV_PRINT_ASCII);
+			} else if ((options & JQ_OPT_RAW_OUTPUT0) &&
+			    strlen(jv_string_value(result)) !=
+			    (unsigned long)jv_string_length_bytes(
+				jv_copy(result))) {
+				jv_free(result);
+				result = jv_invalid_with_msg(jv_string(
+				    "Cannot dump a string containing NUL with --raw-output0 option"));
+				jv_free(result);
+				ret = JQ_ERROR_UNKNOWN;
+				break;
+			} else {
+				fwrite(jv_string_value(result), 1,
+				    (size_t)jv_string_length_bytes(
+					jv_copy(result)),
+				    stdout);
+			}
+			ret = JQ_OK;
+			jv_free(result);
+		} else {
+			if (jv_get_kind(result) == JV_KIND_FALSE ||
+			    jv_get_kind(result) == JV_KIND_NULL)
+				ret = JQ_OK_NULL_KIND;
+			else
+				ret = JQ_OK;
+			if (options & JQ_OPT_SEQ)
+				fwrite("\036", 1, 1, stdout);
+			jv_dumpf(result, stdout, dumpopts);
+		}
+
+		if (!(options & JQ_OPT_RAW_NO_LF))
+			fwrite("\n", 1, 1, stdout);
+		if (options & JQ_OPT_RAW_OUTPUT0)
+			fwrite("\0", 1, 1, stdout);
+		if (options & JQ_OPT_UNBUFFERED)
+			fflush(stdout);
+	}
+
+	if (jq_halted(jq)) {
+		jv exit_code = jq_get_exit_code(jq);
+		if (!jv_is_valid(exit_code))
+			ret = JQ_OK;
+		else if (jv_get_kind(exit_code) == JV_KIND_NUMBER)
+			ret = (int)jv_number_value(exit_code);
+		else
+			ret = JQ_ERROR_UNKNOWN;
+		jv_free(exit_code);
+
+		jv error_message = jq_get_error_message(jq);
+		if (jv_get_kind(error_message) == JV_KIND_STRING) {
+			fwrite(jv_string_value(error_message), 1,
+			    (size_t)jv_string_length_bytes(jv_copy(error_message)),
+			    stderr);
+		} else if (jv_get_kind(error_message) != JV_KIND_NULL &&
+		    jv_is_valid(error_message)) {
+			error_message = jv_dump_string(error_message, 0);
+			fprintf(stderr, "%s\n", jv_string_value(error_message));
+		}
+		fflush(stderr);
+		jv_free(error_message);
+	}
+
+	return ret;
+}
+
+/*
+ * jqcmd:
+ *   jq-compatible builtin using libjq.
+ */
+int
+jqcmd(int argc, char **argv)
+{
+	jq_state *jq = NULL;
+	jq_util_input_state *input_state = NULL;
+	jv ARGS = jv_array();
+	jv program_arguments = jv_object();
+	jv lib_search_paths = jv_null();
+	int options = 0;
+	int parser_flags = 0;
+	int jq_flags = 0;
+	int ret = JQ_OK_NO_OUTPUT;
+	int last_result = -1;
+	int nfiles = 0;
+	int compiled = 0;
+	int further_args_are_strings = 0;
+	int further_args_are_json = 0;
+	int dumpopts = JV_PRINT_INDENT_FLAGS(2);
+	const char *program = NULL;
+	char *program_buf = NULL;
+	size_t program_len = 0;
+
+	jq = jq_init();
+	if (jq == NULL) {
+		fprintf(stderr, "jq: init failed\n");
+		return JQ_ERROR_SYSTEM;
+	}
+
+	input_state = jq_util_input_init(NULL, NULL);
+
+	for (int i = 1; i < argc; i++) {
+		const char *text = argv[i];
+		int is_short = 0;
+
+		if (!jq_isoptish(text)) {
+			if (!program && !(options & JQ_OPT_FROM_FILE)) {
+				program = text;
+				continue;
+			}
+			if (further_args_are_strings) {
+				ARGS = jv_array_append(ARGS,
+				    jv_string(text));
+				continue;
+			}
+			if (further_args_are_json) {
+				jv v = jv_parse(text);
+				if (!jv_is_valid(v)) {
+					fprintf(stderr,
+					    "jq: invalid JSON in --jsonargs\n");
+					ret = JQ_ERROR_SYSTEM;
+					goto out;
+				}
+				ARGS = jv_array_append(ARGS, v);
+				continue;
+			}
+			jq_util_input_add_input(input_state, text);
+			nfiles++;
+			continue;
+		}
+
+		if (!strcmp(text, "--")) {
+			for (i++; i < argc; i++) {
+				if (!program && !(options & JQ_OPT_FROM_FILE)) {
+					program = argv[i];
+					continue;
+				}
+				if (further_args_are_strings) {
+					ARGS = jv_array_append(ARGS,
+					    jv_string(argv[i]));
+					continue;
+				}
+				if (further_args_are_json) {
+					jv v = jv_parse(argv[i]);
+					if (!jv_is_valid(v)) {
+						fprintf(stderr,
+						    "jq: invalid JSON in --jsonargs\n");
+						ret = JQ_ERROR_SYSTEM;
+						goto out;
+					}
+					ARGS = jv_array_append(ARGS, v);
+					continue;
+				}
+				jq_util_input_add_input(input_state, argv[i]);
+				nfiles++;
+			}
+			break;
+		}
+
+		is_short = (text[1] != '-');
+		if (is_short)
+			text++;
+		else
+			text += 2;
+
+		while (text && *text) {
+			if (jq_isoption(&text, 'n', "null-input", is_short)) {
+				options |= JQ_OPT_PROVIDE_NULL;
+			} else if (jq_isoption(&text, 'R', "raw-input",
+			    is_short)) {
+				options |= JQ_OPT_RAW_INPUT;
+			} else if (jq_isoption(&text, 's', "slurp", is_short)) {
+				options |= JQ_OPT_SLURP;
+			} else if (jq_isoption(&text, 'c',
+			    "compact-output", is_short)) {
+				dumpopts &= ~JV_PRINT_PRETTY;
+			} else if (jq_isoption(&text, 'r', "raw-output",
+			    is_short)) {
+				options |= JQ_OPT_RAW_OUTPUT;
+			} else if (jq_isoption(&text, 0, "raw-output0",
+			    is_short)) {
+				options |= JQ_OPT_RAW_OUTPUT | JQ_OPT_RAW_OUTPUT0;
+			} else if (jq_isoption(&text, 'j', "join-output",
+			    is_short)) {
+				options |= JQ_OPT_RAW_OUTPUT | JQ_OPT_RAW_NO_LF;
+			} else if (jq_isoption(&text, 'a', "ascii-output",
+			    is_short)) {
+				options |= JQ_OPT_ASCII_OUTPUT;
+			} else if (jq_isoption(&text, 'S', "sort-keys",
+			    is_short)) {
+				options |= JQ_OPT_SORTED_OUTPUT;
+			} else if (jq_isoption(&text, 'C', "color-output",
+			    is_short)) {
+				options |= JQ_OPT_COLOR_OUTPUT;
+			} else if (jq_isoption(&text, 'M',
+			    "monochrome-output", is_short)) {
+				options |= JQ_OPT_NO_COLOR_OUTPUT;
+			} else if (jq_isoption(&text, 0, "tab", is_short)) {
+				dumpopts &= ~JV_PRINT_INDENT_FLAGS(7);
+				dumpopts |= JV_PRINT_TAB | JV_PRINT_PRETTY;
+			} else if (jq_isoption(&text, 0, "indent",
+			    is_short)) {
+				const char *arg = NULL;
+				char *end = NULL;
+				long indent;
+				if (is_short && text && *text) {
+					arg = text;
+					text = NULL;
+				} else if (i < argc - 1) {
+					arg = argv[++i];
+				} else {
+					fprintf(stderr,
+					    "jq: --indent takes one parameter\n");
+					ret = JQ_ERROR_SYSTEM;
+					goto out;
+				}
+				errno = 0;
+				indent = strtol(arg, &end, 10);
+				if (errno || indent < -1 || indent > 7 ||
+				    end == arg || *end) {
+					fprintf(stderr,
+					    "jq: --indent takes a number between -1 and 7\n");
+					ret = JQ_ERROR_SYSTEM;
+					goto out;
+				}
+				dumpopts &= ~(JV_PRINT_TAB |
+				    JV_PRINT_INDENT_FLAGS(7));
+				dumpopts |= JV_PRINT_INDENT_FLAGS(indent);
+			} else if (jq_isoption(&text, 0, "unbuffered",
+			    is_short)) {
+				options |= JQ_OPT_UNBUFFERED;
+			} else if (jq_isoption(&text, 0, "stream", is_short)) {
+				parser_flags |= JV_PARSE_STREAMING;
+			} else if (jq_isoption(&text, 0, "stream-errors",
+			    is_short)) {
+				parser_flags |=
+				    JV_PARSE_STREAMING | JV_PARSE_STREAM_ERRORS;
+			} else if (jq_isoption(&text, 0, "seq", is_short)) {
+				options |= JQ_OPT_SEQ;
+			} else if (jq_isoption(&text, 'e', "exit-status",
+			    is_short)) {
+				options |= JQ_OPT_EXIT_STATUS;
+			} else if (jq_isoption(&text, 0, "args", is_short)) {
+				further_args_are_strings = 1;
+				further_args_are_json = 0;
+			} else if (jq_isoption(&text, 0, "jsonargs",
+			    is_short)) {
+				further_args_are_strings = 0;
+				further_args_are_json = 1;
+			} else if (jq_isoption(&text, 0, "arg", is_short)) {
+				if (i >= argc - 2) {
+					fprintf(stderr,
+					    "jq: --arg takes two parameters\n");
+					ret = JQ_ERROR_SYSTEM;
+					goto out;
+				}
+				if (!jv_object_has(jv_copy(program_arguments),
+				    jv_string(argv[i + 1]))) {
+					program_arguments = jv_object_set(
+					    program_arguments,
+					    jv_string(argv[i + 1]),
+					    jv_string(argv[i + 2]));
+				}
+				i += 2;
+				text = NULL;
+			} else if (jq_isoption(&text, 0, "argjson",
+			    is_short)) {
+				if (i >= argc - 2) {
+					fprintf(stderr,
+					    "jq: --argjson takes two parameters\n");
+					ret = JQ_ERROR_SYSTEM;
+					goto out;
+				}
+				if (!jv_object_has(jv_copy(program_arguments),
+				    jv_string(argv[i + 1]))) {
+					jv v = jv_parse(argv[i + 2]);
+					if (!jv_is_valid(v)) {
+						fprintf(stderr,
+						    "jq: invalid JSON text passed to --argjson\n");
+						ret = JQ_ERROR_SYSTEM;
+						goto out;
+					}
+					program_arguments = jv_object_set(
+					    program_arguments,
+					    jv_string(argv[i + 1]), v);
+				}
+				i += 2;
+				text = NULL;
+			} else if (jq_isoption(&text, 0, "rawfile",
+			    is_short) ||
+			    jq_isoption(&text, 0, "slurpfile", is_short) ||
+			    jq_isoption(&text, 0, "argfile", is_short)) {
+				int raw = strstr(argv[i], "rawfile") != NULL;
+				const char *which = raw ? "rawfile" : "slurpfile";
+				if (i >= argc - 2) {
+					fprintf(stderr,
+					    "jq: --%s takes two parameters\n",
+					    which);
+					ret = JQ_ERROR_SYSTEM;
+					goto out;
+				}
+				if (!jv_object_has(jv_copy(program_arguments),
+				    jv_string(argv[i + 1]))) {
+					jv data = jv_load_file(argv[i + 2],
+					    raw);
+					if (!jv_is_valid(data)) {
+						data = jv_invalid_get_msg(data);
+						fprintf(stderr,
+						    "jq: Bad JSON in --%s %s %s: %s\n",
+						    which, argv[i + 1], argv[i + 2],
+						    jv_string_value(data));
+						jv_free(data);
+						ret = JQ_ERROR_SYSTEM;
+						goto out;
+					}
+					program_arguments = jv_object_set(
+					    program_arguments,
+					    jv_string(argv[i + 1]), data);
+				}
+				i += 2;
+				text = NULL;
+			} else if (jq_isoption(&text, 'f', "from-file",
+			    is_short)) {
+				const char *arg = NULL;
+				if (is_short && text && *text) {
+					arg = text;
+					text = NULL;
+				} else if (i < argc - 1) {
+					arg = argv[++i];
+				} else {
+					fprintf(stderr,
+					    "jq: -f takes a parameter\n");
+					ret = JQ_ERROR_SYSTEM;
+					goto out;
+				}
+				jv data = jv_load_file(arg, 1);
+				if (!jv_is_valid(data)) {
+					data = jv_invalid_get_msg(data);
+					fprintf(stderr, "jq: %s\n",
+					    jv_string_value(data));
+					jv_free(data);
+					ret = JQ_ERROR_SYSTEM;
+					goto out;
+				}
+				if (!jq_append_program(&program_buf,
+				    &program_len, jv_string_value(data),
+				    (size_t)jv_string_length_bytes(
+					jv_copy(data)))) {
+					jv_free(data);
+					ret = JQ_ERROR_SYSTEM;
+					goto out;
+				}
+				jv_free(data);
+				options |= JQ_OPT_FROM_FILE;
+			} else if (jq_isoption(&text, 'L', "library-path",
+			    is_short)) {
+				const char *arg = NULL;
+				if (is_short && text && *text) {
+					arg = text;
+					text = NULL;
+				} else if (i < argc - 1) {
+					arg = argv[++i];
+				} else {
+					fprintf(stderr,
+					    "jq: -L takes a parameter\n");
+					ret = JQ_ERROR_SYSTEM;
+					goto out;
+				}
+				if (jv_get_kind(lib_search_paths) ==
+				    JV_KIND_NULL)
+					lib_search_paths = jv_array();
+				lib_search_paths = jv_array_append(
+				    lib_search_paths, jv_string(arg));
+			} else if (jq_isoption(&text, 'h', "help", is_short)) {
+				jq_usage_short();
+				ret = JQ_OK;
+				goto out;
+			} else if (jq_isoption(&text, 'V', "version",
+			    is_short)) {
+				printf("jq (libjq)\n");
+				ret = JQ_OK;
+				goto out;
+			} else {
+				fprintf(stderr, "jq: Unknown option\n");
+				jq_usage_short();
+				ret = JQ_ERROR_SYSTEM;
+				goto out;
+			}
+		}
+	}
+
+	if (!program && !(options & JQ_OPT_FROM_FILE))
+		program = ".";
+
+	if (jv_get_kind(lib_search_paths) == JV_KIND_NULL) {
+		lib_search_paths = JV_ARRAY(jv_string("~/.jq"),
+		    jv_string("$ORIGIN/../lib/jq"),
+		    jv_string("$ORIGIN/../lib"));
+	}
+	jq_set_attr(jq, jv_string("JQ_LIBRARY_PATH"), lib_search_paths);
+	jq_set_attr(jq, jv_string("JQ_ORIGIN"), jv_string("."));
+
+	if (isatty(STDOUT_FILENO)) {
+		dumpopts |= JV_PRINT_ISATTY | JV_PRINT_COLOR;
+		const char *no_color = getenv("NO_COLOR");
+		if (no_color && *no_color)
+			dumpopts &= ~JV_PRINT_COLOR;
+	}
+	if (options & JQ_OPT_SORTED_OUTPUT)
+		dumpopts |= JV_PRINT_SORTED;
+	if (options & JQ_OPT_ASCII_OUTPUT)
+		dumpopts |= JV_PRINT_ASCII;
+	if (options & JQ_OPT_COLOR_OUTPUT)
+		dumpopts |= JV_PRINT_COLOR;
+	if (options & JQ_OPT_NO_COLOR_OUTPUT)
+		dumpopts &= ~JV_PRINT_COLOR;
+
+	jq_set_colors(getenv("JQ_COLORS"));
+
+	ARGS = JV_OBJECT(jv_string("positional"), ARGS,
+	    jv_string("named"), jv_copy(program_arguments));
+	program_arguments = jv_object_set(program_arguments, jv_string("ARGS"),
+	    jv_copy(ARGS));
+
+	if (options & JQ_OPT_FROM_FILE) {
+		if (!program_buf || !*program_buf)
+			program = ".";
+		else
+			program = program_buf;
+	}
+
+	compiled = jq_compile_args(jq, program, jv_copy(program_arguments));
+	if (!compiled) {
+		ret = JQ_ERROR_COMPILE;
+		goto out;
+	}
+
+	if (options & JQ_OPT_SEQ)
+		parser_flags |= JV_PARSE_SEQ;
+
+	if (options & JQ_OPT_RAW_INPUT)
+		jq_util_input_set_parser(input_state, NULL,
+		    (options & JQ_OPT_SLURP) ? 1 : 0);
+	else
+		jq_util_input_set_parser(input_state,
+		    jv_parser_new(parser_flags),
+		    (options & JQ_OPT_SLURP) ? 1 : 0);
+
+	jq_set_input_cb(jq, jq_util_input_next_input_cb, input_state);
+
+	if (nfiles == 0)
+		jq_util_input_add_input(input_state, "-");
+
+	if (options & JQ_OPT_PROVIDE_NULL) {
+		ret = jq_process(jq, jv_null(), jq_flags, dumpopts, options);
+	} else {
+		jv value;
+		while (jq_util_input_errors(input_state) == 0 &&
+		    (jv_is_valid((value = jq_util_input_next_input(input_state))) ||
+		    jv_invalid_has_msg(jv_copy(value)))) {
+			if (jv_is_valid(value)) {
+				ret = jq_process(jq, value, jq_flags, dumpopts,
+				    options);
+				if (ret <= 0 && ret != JQ_OK_NO_OUTPUT)
+					last_result = (ret != JQ_OK_NULL_KIND);
+				if (jq_halted(jq))
+					break;
+				continue;
+			}
+
+			jv msg = jv_invalid_get_msg(value);
+			if (!(options & JQ_OPT_SEQ)) {
+				ret = JQ_ERROR_UNKNOWN;
+				fprintf(stderr, "jq: parse error: %s\n",
+				    jv_string_value(msg));
+				jv_free(msg);
+				break;
+			}
+			fprintf(stderr, "jq: ignoring parse error: %s\n",
+			    jv_string_value(msg));
+			jv_free(msg);
+		}
+	}
+
+	if (jq_util_input_errors(input_state) != 0)
+		ret = JQ_ERROR_SYSTEM;
+
+out:
+	if (program_buf)
+		free(program_buf);
+	jv_free(ARGS);
+	jv_free(program_arguments);
+	jq_util_input_free(&input_state);
+	jq_teardown(&jq);
+
+	if (options & JQ_OPT_EXIT_STATUS) {
+		if (ret != JQ_OK_NO_OUTPUT)
+			return abs(ret);
+		switch (last_result) {
+		case -1:
+			return abs(JQ_OK_NO_OUTPUT);
+		case 0:
+			return abs(JQ_OK_NULL_KIND);
+		default:
+			return abs(JQ_OK);
+		}
+	}
+
+	return ret > 0 ? ret : 0;
+}

--- a/bin/cbsdsh/src/options.c
+++ b/bin/cbsdsh/src/options.c
@@ -144,7 +144,7 @@ char* find_command_in_path(const char* command_name, const char* env_var_name) {
 	if (command_name[0] == '/' ) {
 		// Check if the file exists and is executable
 		if (access(command_name, F_OK | X_OK) == 0)
-			return command_name; // Found it
+			return (char *)command_name; // Found it
 		else
 			return NULL;
 	}

--- a/bin/cbsdsh/src/options.c
+++ b/bin/cbsdsh/src/options.c
@@ -144,7 +144,7 @@ char* find_command_in_path(const char* command_name, const char* env_var_name) {
 	if (command_name[0] == '/' ) {
 		// Check if the file exists and is executable
 		if (access(command_name, F_OK | X_OK) == 0)
-			return (char *)command_name; // Found it
+			return command_name; // Found it
 		else
 			return NULL;
 	}

--- a/bin/cbsdsh/src/parser.c
+++ b/bin/cbsdsh/src/parser.c
@@ -1348,7 +1348,7 @@ parseredir: {
 
 parsesub: {
 	const char *newsyn = synstack->syntax;
-	static const char types[] = "}-+?=";
+	static const char types[] = "}-+?=@";
 	int subtype;
 	char *p;
 

--- a/bin/cbsdsh/src/parser.h
+++ b/bin/cbsdsh/src/parser.h
@@ -61,11 +61,12 @@ union node;
 #define VSPLUS		0x3		/* ${var+text} */
 #define VSQUESTION	0x4		/* ${var?message} */
 #define VSASSIGN	0x5		/* ${var=text} */
-#define VSTRIMRIGHT	0x6		/* ${var%pattern} */
-#define VSTRIMRIGHTMAX 	0x7		/* ${var%%pattern} */
-#define VSTRIMLEFT	0x8		/* ${var#pattern} */
-#define VSTRIMLEFTMAX	0x9		/* ${var##pattern} */
-#define VSLENGTH	0xa		/* ${#var} */
+#define VSJQEXPR	0x6		/* ${var@jqexpr} */
+#define VSTRIMRIGHT	0x7		/* ${var%pattern} */
+#define VSTRIMRIGHTMAX 	0x8		/* ${var%%pattern} */
+#define VSTRIMLEFT	0x9		/* ${var#pattern} */
+#define VSTRIMLEFTMAX	0xa		/* ${var##pattern} */
+#define VSLENGTH	0xb		/* ${#var} */
 /* VSLENGTH must come last. */
 
 /* values of checkkwd variable */

--- a/bin/cbsdsh/src/sqlcmd.c
+++ b/bin/cbsdsh/src/sqlcmd.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <ctype.h>
 #include <unistd.h>
+#include <string.h>
 
 #include "shell.h"
 #include "main.h"
@@ -22,6 +23,8 @@
 #include <stdbool.h>
 
 #include "sqlcmd.h"
+
+#include <jv.h>
 
 #define CBSD_SQLITE_BUSY_TIMEOUT 25000
 
@@ -323,6 +326,148 @@ sqlitecmdro(int argc, char **argv)
 	if (stmt)
 		sqlite3_finalize(stmt);
 	free(query);
+	sqlite3_close(db);
+
+	return 0;
+}
+
+/*
+ * sqlitecmdquery:
+ *   Read-only query against dbfile and print one JSON per row to stdout.
+ *
+ * Usage (in shell):
+ *   cbsdsqlquery <dbfile> "<query>"
+ */
+int
+sqlitecmdquery(int argc, char **argv)
+{
+	sqlite3 *db;
+	int res;
+	char *dbdir;
+	char *dbfile;
+	int ret = 0;
+	sqlite3_stmt *stmt = NULL;
+	int maxretry = 50;
+	int retry = 0;
+	if (argc != 3) {
+		out1fmt("usage: cbsdsqlquery <dbfile> <query>\n");
+		return 1;
+	}
+
+	if (argv[1][0] != '/') {
+		dbdir = lookupvar("dbdir");
+		if (!dbdir) {
+			out1fmt("dbdir not set!\n");
+			return 1;
+		}
+		size_t dbfile_len = strlen(dbdir) + strlen(argv[1]) +
+		    strlen(DBPOSTFIX) + 2;
+		dbfile = calloc(dbfile_len, sizeof(char));
+		if (dbfile == NULL) {
+			out1fmt("Out of memory!\n");
+			return 1;
+		}
+		snprintf(dbfile, dbfile_len, "%s/%s%s", dbdir, argv[1],
+		    DBPOSTFIX);
+	} else {
+		size_t dbfile_len = strlen(argv[1]) + 1;
+		dbfile = calloc(dbfile_len, sizeof(char));
+		if (dbfile == NULL) {
+			out1fmt("Out of memory!\n");
+			return 1;
+		}
+		snprintf(dbfile, dbfile_len, "%s", argv[1]);
+	}
+
+	if (SQLITE_OK !=
+	    (res = sqlite3_open_v2(dbfile, &db,
+		 SQLITE_OPEN_READONLY | SQLITE_OPEN_SHAREDCACHE, NULL))) {
+		out1fmt("%s: Can't open database file: %s\n", nm(), dbfile);
+		free(dbfile);
+		return 1;
+	}
+	free(dbfile);
+
+	sqlite3_busy_timeout(db, CBSD_SQLITE_BUSY_TIMEOUT);
+	sql_exec(db, "PRAGMA mmap_size = 209715200;");
+	sqlite3_db_config(db, SQLITE_DBCONFIG_DQS_DDL, 1, (void *)0);
+	sqlite3_db_config(db, SQLITE_DBCONFIG_DQS_DML, 1, (void *)0);
+
+	do {
+		ret = sqlite3_prepare_v2(db, argv[2], -1, &stmt, NULL);
+		if (ret == SQLITE_OK)
+			break;
+		retry++;
+		if (retry > maxretry)
+			break;
+	} while (ret != SQLITE_OK);
+
+	if (ret == SQLITE_OK) {
+		ret = sqlite3_step(stmt);
+		while (ret == SQLITE_ROW) {
+			int icol;
+			int allcol = sqlite3_column_count(stmt);
+			jv row = jv_object();
+
+			for (icol = 0; icol < allcol; icol++) {
+				const char *colname =
+				    sqlite3_column_name(stmt, icol);
+				switch (sqlite3_column_type(stmt, icol)) {
+				case SQLITE_INTEGER:
+					row = jv_object_set(row,
+					    jv_string(colname),
+					    jv_number(
+						(double)sqlite3_column_int64(
+						    stmt, icol)));
+					break;
+				case SQLITE_FLOAT:
+					row = jv_object_set(row,
+					    jv_string(colname),
+					    jv_number(
+						sqlite3_column_double(stmt,
+						    icol)));
+					break;
+				case SQLITE_TEXT: {
+					const unsigned char *txt_uc =
+					    sqlite3_column_text(stmt, icol);
+					const char *txt = txt_uc
+					    ? (const char *)txt_uc
+					    : "";
+					row = jv_object_set(row,
+					    jv_string(colname),
+					    jv_string(txt));
+					break;
+				}
+				case SQLITE_NULL:
+					row = jv_object_set(row,
+					    jv_string(colname), jv_null());
+					break;
+				case SQLITE_BLOB:
+				default:
+					row = jv_object_set(row,
+					    jv_string(colname), jv_null());
+					break;
+				}
+			}
+			jv dumped = jv_dump_string(row, 0);
+			if (!jv_is_valid(dumped)) {
+				jv msg = jv_invalid_get_msg(jv_copy(dumped));
+				out1fmt("%s\n", jv_string_value(msg));
+				jv_free(msg);
+				jv_free(dumped);
+				jv_free(row);
+				ret = 1;
+				break;
+			}
+			out1fmt("%s\n", jv_string_value(dumped));
+			jv_free(dumped);
+			jv_free(row);
+			ret = sqlite3_step(stmt);
+		}
+	}
+
+	if (stmt)
+		sqlite3_finalize(stmt);
 	sqlite3_close(db);
 
 	return 0;

--- a/jailctl/jstart
+++ b/jailctl/jstart
@@ -1,2 +1,2 @@
 #!/usr/local/bin/cbsd
-. ${subrdir}/sudoexec.subr
+. ${subrdir}/new_sudoexec.subr

--- a/sudoexec/jstart
+++ b/sudoexec/jstart
@@ -831,9 +831,11 @@ fi
 
 # for VNET-based jail we also need special route
 # due to jail.conf doesn't support for multiple NICs
-setup_jail_vnet
+if [ ${vnet} -eq 1 ]; then
+	setup_jail_vnet
+	late_start="${exec_start}"
+fi
 
-late_start="${exec_start}"
 if [ -n "${late_start}" ]; then
 	[ ${quiet} -ne 1 ] && ${ECHO} "${N1_COLOR}late_start in progress...${N2_COLOR}"
 	# todo: FIB? NICE?


### PR DESCRIPTION
Now variables can be expanded as JSON jq expression, like `${j@.jid}` 
in general format as `${<varname>@<jq-expression>}`

Add build-in `cbsdsqlquery <db> <query>` which will return SQL results as JSON object per row

So, now it is quite natural to itterate over DB rows as:

```shell
cbsd# cbsdsqlquery /jails/var/db/local.sqlite "SELECT * FROM jails" | \
while read j; do
       printf "%6s %-20s %s\n" ${j@.jid} ${j@.jname} ${j@.host_hostname}
done
```

Also, add jq as buildin tool, anyway we have libjq onboard already.