### PR TITLE
Add support for here-string syntax

### DIFF
--- a/bin/cbsdsh/src/jobs.c
+++ b/bin/cbsdsh/src/jobs.c
@@ -1379,6 +1379,9 @@ dotail2:
 	case NXHERE:
 		p = "<<...";
 		goto dotail2;
+	case NSTRING:
+		p = "<<<...";
+		goto dotail2;
 	case NCASE:
 		cmdputs("case ");
 		cmdputs(n->ncase.expr->narg.text);

--- a/bin/cbsdsh/src/nodetypes
+++ b/bin/cbsdsh/src/nodetypes
@@ -141,6 +141,7 @@ NFROMFD ndup			# fd>&dupfd
 
 NHERE nhere			# fd<<\!
 NXHERE nhere			# fd<<!
+NSTRING nhere			# fd<<<
 	type	  int
 	next	  nodeptr		# next redirection in list
 	fd	  int			# file descriptor being redirected

--- a/bin/cbsdsh/src/parser.c
+++ b/bin/cbsdsh/src/parser.c
@@ -659,6 +659,14 @@ parsefname(void)
 			for (p = heredoclist ; p->next ; p = p->next);
 			p->next = here;
 		}
+	} else if (n->type == NSTRING) {
+		union node *doc;
+		doc = (union node *)stalloc(sizeof (struct narg));
+		doc->narg.type = NARG;
+		doc->narg.next = NULL;
+		doc->narg.text = wordtext;
+		doc->narg.backquote = backquotelist;
+		n->nhere.doc = doc;
 	} else if (n->type == NTOFD || n->type == NFROMFD) {
 		fixredir(n, wordtext, 0);
 	} else {
@@ -1310,9 +1318,14 @@ parseredir: {
 				np->nfile.fd = 0;
 			}
 			np->type = NHERE;
+			c = pgetc_eatbnl();
+			if (c == '<') {
+				np->type = NSTRING;
+				break;
+			}
 			heredoc = (struct heredoc *)stalloc(sizeof (struct heredoc));
 			heredoc->here = np;
-			if ((c = pgetc_eatbnl()) == '-') {
+			if (c == '-') {
 				heredoc->striptabs = 1;
 			} else {
 				heredoc->striptabs = 0;

--- a/bin/cbsdsh/src/redir.c
+++ b/bin/cbsdsh/src/redir.c
@@ -276,6 +276,7 @@ do_open:
 		/* Fall through to eliminate warning. */
 	case NHERE:
 	case NXHERE:
+	case NSTRING:
 		f = openhere(redir);
 		break;
 	}
@@ -359,16 +360,23 @@ openhere(union node *redir)
 	char *p;
 
 	p = redir->nhere.doc->narg.text;
-	if (redir->type == NXHERE) {
+	if (redir->type == NXHERE || redir->type == NSTRING) {
 		expandarg(redir->nhere.doc, NULL, EXP_QUOTED);
 		p = stackblock();
 	}
 
 	len = strlen(p);
+	if (redir->type == NSTRING)
+		len++;
 	memfd = sh_pipe(pip, len > PIPESIZE);
 
 	if (memfd || len <= PIPESIZE) {
-		xwrite(pip[1], p, len);
+		if (redir->type == NSTRING) {
+			xwrite(pip[1], p, len - 1);
+			xwrite(pip[1], "\n", 1);
+		} else {
+			xwrite(pip[1], p, len);
+		}
 		lseek(pip[1], 0, SEEK_SET);
 		goto out;
 	}
@@ -382,7 +390,12 @@ openhere(union node *redir)
 		signal(SIGTSTP, SIG_IGN);
 #endif
 		signal(SIGPIPE, SIG_DFL);
-		xwrite(pip[1], p, len);
+		if (redir->type == NSTRING) {
+			xwrite(pip[1], p, len - 1);
+			xwrite(pip[1], "\n", 1);
+		} else {
+			xwrite(pip[1], p, len);
+		}
 		_exit(0);
 	}
 out:


### PR DESCRIPTION
Add support for here-string syntax

New syntax:

```shell
cbsd# cmd   <<< STRING
cbsd# cmd fd<<< STRING
```

Text STRING supplied on stdin/fd for cmd